### PR TITLE
Fix/prep days warning

### DIFF
--- a/R_functions/prep_days.R
+++ b/R_functions/prep_days.R
@@ -138,6 +138,14 @@ prep_days <- function(
     
     # 
   }else{
+    selected_day_length <- switch(
+      day_length, # the input argument, from `params$day_length_expansion`
+      "dawn/dusk" = "day_length_dawn_dusk",
+      "sunrise/sunset" = "day_length_sunrise_sunset",
+      "night closure"  = "day_length_night_closure",
+      stop("Invalid `day_length`: ", day_length)
+    )
+    
     day_length_values <- suncalc::getSunlightTimes(
       date = days$event_date,
       tz = "America/Los_Angeles",
@@ -150,13 +158,7 @@ prep_days <- function(
         day_length_sunrise_sunset = as.numeric((sunset) - (sunrise)),
         day_length_night_closure = as.numeric((sunset + 3600) - (sunrise - 3600)),
       ) |> 
-      mutate(
-        day_length = case_when(
-          day_length == "dawn/dusk" ~ day_length_dawn_dusk,
-          day_length == "sunrise/sunset" ~ day_length_sunrise_sunset,
-          day_length == "night closure" ~ day_length_night_closure
-        )
-      ) |> 
+      mutate(day_length = .data[[selected_day_length]]) |> 
       select(event_date, day_length)
   }
   

--- a/R_functions/prep_days.R
+++ b/R_functions/prep_days.R
@@ -63,10 +63,12 @@ prep_days <- function(
     week = as.numeric(format(event_date, "%W")),
     month = as.numeric(format(event_date, "%m")),
     year = as.numeric(format(event_date, "%Y")),
-    period = case_when(
-      period_pe == "week" ~ week,
-      period_pe == "month" ~ month,
-      period_pe == "duration" ~ double(1)
+    period = switch(
+      period_pe,
+      week = week,
+      month = month,
+      duration = double(1),
+      stop("Invalid `period_pe`: ", period_pe)
     ),
     day_index = as.integer(seq_along(event_date)),
     week_index = as.integer(factor(week, levels = unique(week))),


### PR DESCRIPTION
`prep_days()` was using `dplyr::case_when()` twice in a way that is no longer supported after `dplyr v1.2.0`. 

period_pe (`params$period_pe` at the call site) is a single character value with options "week", "month", or "duration". When using this scalar value to apply to an entire column of new values with *n* rows, it triggered a warning about "size 1 LHS inputs and size >1 RHS inputs". The same situation occurred for `day_length` where double-named argument day_length `params$day_length_expansion` at the call site) with options "night closure", "sunrise/sunset", and "dawn/dusk" was being used to create a new column with `dplyr::mutate()`. I moved this outside of that pipe and defined as an object `selected_day_length` and used that in the argument via `.data$` call with is package-friendly scoping for eventual `devtools::check()` review.

In both cases, `case_when()` was replaced with base R `switch()`. https://tidyverse.org/blog/2026/02/dplyr-1-2-0/#deprecations documentation on change to `case_when()`

Closes #70, see for more details on the warning that this PR dismisses.