### PR TITLE
Fix: census expansion chunk errors for Drano study design

### DIFF
--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -659,35 +659,46 @@ saveRDS(inputs_pe, file.path(outputs_folders$inputs, "inputs_pe.rds"))
 ### Paired census and index angler effort counts
 
 ```{r view_paired_census_index_counts, cache=params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_pe")}
-
-if (nrow(dwg_summ$effort_census) > 0) {
-  # table view of census / index surveys and resulting bias term ratio 
-  inputs_pe$paired_census_index_counts |> 
-    gt() |> 
-    tab_header(
-      title = "The season-long sum of paired census and index angler effort counts and corresponding bias-term ratio (TI_expan_final), indicating the magnitude and direction (postive or negative) of bias in index counts relative to census counts."
-    ) |>
-    tab_options(
-      heading.title.font.size = px(14),
-      table.font.color = "black"
-    ) |> 
-    fmt_number(c(TI_expan_weighted, TI_expan_final), decimals = 2) |> 
-    fmt_number(c(count_census, count_index), decimals = 0)
+# Skip table for Drano study design (no census-index effort bias correction)
+if (!params$study_design == "Drano") {
+  # For study designs other than "Drano", skip if there has not been a census effort count
+  if (nrow(dwg_summ$effort_census) > 0) {
+    # table view of census / index surveys and resulting bias term ratio 
+    inputs_pe$paired_census_index_counts |> 
+      gt() |> 
+      tab_header(
+        title = "The season-long sum of paired census and index angler effort counts and corresponding bias-term ratio (TI_expan_final), indicating the magnitude and direction (postive or negative) of bias in index counts relative to census counts."
+      ) |>
+      tab_options(
+        heading.title.font.size = px(14),
+        table.font.color = "black"
+      ) |> 
+      fmt_number(c(TI_expan_weighted, TI_expan_final), decimals = 2) |> 
+      fmt_number(c(count_census, count_index), decimals = 0)
+  } else {
+    gt(data.frame(
+      msg = "No census effort count data was detected. Substituting a 1.0 census-index bias ratio for each section and angler type combination. This assumes there is no systematic bias in the index effort data relative to census counts."
+    )) |>
+    tab_options(column_labels.hidden = TRUE, table.font.size = gt::px(14), table.font.color = "black")
+  }
 } else {
-  gt(data.frame(
-    msg = "No census effort count data was detected. Substituting a 1.0 census-index bias ratio for each section and angler type combination. This assumes there is no systematic bias in the index effort data relative to census counts."
-  )) |>
-  tab_options(column_labels.hidden = TRUE, table.font.size = gt::px(14), table.font.color = "black")
+  # Print message on Drano reports
+  cat("Drano study design: paired index-census bias correction table not applicable. Each index effort count is treated as a census of angler effort.")
 }
 ```
 
 ```{r scatterplot_census_v_index, fig.cap= "Scatterplot displaying the effort bias-term ratio (TI_expan_final) for each section and angler type (angler_final), representing the total count from census surveys divided by the total count from index surveys. A 1:1 relationship is shown by the dashed line.", dependson=c("establish_file_structure", "prep_inputs_pe")}
-
-if (nrow(dwg_summ$effort_census) > 0) {
-  plot_inputs_pe_census_vs_index(census_TI_expan = inputs_pe$paired_census_index_counts) +
-    theme(plot.caption = element_text(size = 10, hjust = 0))
+# Skip table for Drano study design (no census-index effort bias correction)
+if (!params$study_design == "Drano") {
+  # For study designs other than "Drano", skip if there has not been a census effort count
+  if (nrow(dwg_summ$effort_census) > 0) {
+    plot_inputs_pe_census_vs_index(census_TI_expan = inputs_pe$paired_census_index_counts) +
+      theme(plot.caption = element_text(size = 10, hjust = 0))
+  }
+} else {
+  # Print message on Drano reports
+  cat("Drano study design: paired index-census bias correction table not applicable. Each index effort count is treated as a census of angler effort.")
 }
-
 ```
 
 ### Generate PE estimates


### PR DESCRIPTION
There are two chunks in the template script that fail for runs with `params$study_design = "Drano"`. Those code chunks are "view_paired_census_index_counts" and "scatterplot_census_v_index". The Drano study design type considers index counts as a census of angler effort, so no index-census bias correction (`TI_expan_final`) is calculated. This results in object `inputs_pe$paired_census_index_counts` not having the same columns it would have if `params$study_design = "Standard"`. See issue #79 for more background. 

```
# fail point for table
fmt_number(c(TI_expan_weighted, TI_expan_final), decimals = 2) |> 
fmt_number(c(count_census, count_index), decimals = 0)

# fail point for plot
plot_inputs_pe_census_vs_index(census_TI_expan = inputs_pe$paired_census_index_counts) +
```

I added a conditional statement around each chunk to skip when params is set for Drano. When this occurs, a message is returned rather than silently moving on.
```
if (!params$study_design == "Drano") {
    ...
} else {
  cat("Drano study design: paired index-census bias correction table not applicable. 
       Each index effort count is treated as a census of angler effort.")
}
```

Behavior:
- When `params$study_design = "Drano"`, the index-census bias correction table and plot are skipped and a message is returned.
- When `params$study_design = "Standard"` and no census effort counts are recorded within `params$est_date_[start/end]`, a fallback index-census bias correction value of 1.0 is used. This is typically only done for estimates produced very early in a fishery. 
- When `params$study_design = "Standard"` and there are one more or census effort counts (`dwg_summ$effort_census`), the standard table and plot are produced.