### PR TITLE
feature/resolve-catch-groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ config.yml
 # Dev container configuration
 .devcontainer/
 .devcontainer
+.positai

--- a/R_functions/generate_analysis_lut.R
+++ b/R_functions/generate_analysis_lut.R
@@ -58,7 +58,7 @@ generate_analysis_lut <- function(resolved_params, current_file_path = NULL) {
     
     # Generate session-specific analysis uuid
     analysis_id <- uuid::UUIDgenerate()
-    analysis_id <- toupper(analysis_id)  # Capitalize to match database format
+    analysis_id <- tolower(analysis_id)  # force lowercase (PostgreSQL standard)
     cli::cli_alert_success("New analysis_id created: {.val {substr(analysis_id, 1, 8)}...}")
     
     # Create fishery identifier

--- a/R_functions/generate_analysis_lut.R
+++ b/R_functions/generate_analysis_lut.R
@@ -1,5 +1,11 @@
 # Function to generate or load analysis lookup table with session-specific uuid
-generate_analysis_lut <- function(params, current_file_path = NULL) {
+#
+# `resolved_params` is built in fw_creel.Rmd after resolve_dates() and
+# resolve_catch_groups() run: the YAML params list overlaid with resolver
+# outputs (est_date_start, est_date_end, model_run_type, est_catch_groups).
+# The same object is later passed through the export pipeline
+# (finalize_analysis_lut() / export_estimates()) in place of raw params.
+generate_analysis_lut <- function(resolved_params, current_file_path = NULL) {
   
   # Try to get current file path if not provided
   if (is.null(current_file_path)) {
@@ -30,6 +36,15 @@ generate_analysis_lut <- function(params, current_file_path = NULL) {
       
       if (file.exists(lut_file)) {
         existing_analysis_lut <- readRDS(lut_file)
+        
+        # Legacy (ETL 1.0) luts carry analysis_name; still usable for local
+        # work, but finalize_analysis_lut() will abort at export time
+        if ("analysis_name" %in% names(existing_analysis_lut)) {
+          cli::cli_alert_warning(
+            "Legacy (ETL 1.0) analysis_lut loaded; database export will fail. Start a new session to export."
+          )
+        }
+        
         cli::cli_alert_success("Loaded existing analysis_lut from {.path {lut_file}}")
         cli::cli_alert_info("Using analysis_id: {.val {existing_analysis_lut$analysis_id}}")
         assign("analysis_lut", existing_analysis_lut, envir = .GlobalEnv)
@@ -47,7 +62,7 @@ generate_analysis_lut <- function(params, current_file_path = NULL) {
     cli::cli_alert_success("New analysis_id created: {.val {substr(analysis_id, 1, 8)}...}")
     
     # Create fishery identifier
-    fishery_name <- params$fishery_name
+    fishery_name <- resolved_params$fishery_name
     year_format <- dplyr::case_when(
       stringr::str_detect(fishery_name, "\\d{4}-\\d{2}") ~ "yyyy-yy",
       stringr::str_detect(fishery_name, "\\b\\d{4}\\b") ~ "yyyy",
@@ -70,28 +85,37 @@ generate_analysis_lut <- function(params, current_file_path = NULL) {
     identifier <- paste0(initials, last_two_digits)
     
     # Create analysis folder name: IDENTIFIER_LAST4_YYYYMMDD
-    analysis_folder <- paste(
+    analysis_folder_name <- paste(
       identifier,
       stringr::str_sub(analysis_id, -4),
       format(Sys.Date(), "%Y%m%d"),
       sep = "_"
     )
     
+    # Git metadata: SHA and tag only when HEAD on a tag
+    git_sha <- tryCatch(
+      system("git rev-parse HEAD", intern = TRUE),
+      error = function(e) NA_character_
+    )
+    git_tag <- tryCatch({
+      tag <- system("git tag --points-at HEAD", intern = TRUE)
+      if (length(tag) == 0) NA_character_ else tag[1]
+    }, error = function(e) NA_character_)
+
+    params_json <- as.character(
+      jsonlite::toJSON(resolved_params, auto_unbox = TRUE, pretty = TRUE)
+    )
+    
     # Create analysis_lut data frame
     analysis_lut <- data.frame(
       analysis_id = analysis_id,
-      analysis_name = paste0(
-        params$fishery_name, "_", params$data_grade, "_",
-        format(Sys.time(), format = "%Y-%m-%dT%H:%M:%SZ")
-      ),
-      fishery_name = params$fishery_name,
-      identifier = identifier,
-      analysis_folder = analysis_folder,
-      repo_version = tryCatch({
-        paste0("https://github.com/wdfw-fp/CreelEstimates/tree/",
-               system("git rev-parse HEAD", intern = TRUE))
-      }, error = function(e) "Git version unavailable"),
-      created_datetime = format(Sys.time(), format = "%Y-%m-%dT%H:%M:%SZ"),
+      project_name = resolved_params$project_name,
+      fishery_name = fishery_name,
+      analysis_folder_name = analysis_folder_name,
+      model_run_type = resolved_params$model_run_type,
+      git_sha = git_sha,
+      git_tag = git_tag,
+      params_json = params_json,
       stringsAsFactors = FALSE
     )
     

--- a/R_functions/generate_analysis_lut.R
+++ b/R_functions/generate_analysis_lut.R
@@ -11,10 +11,17 @@ generate_analysis_lut <- function(resolved_params, current_file_path = NULL) {
   if (is.null(current_file_path)) {
     current_file_path <- tryCatch({
       if (!is.null(knitr::current_input()) && knitr::current_input() != "") {
-        here::here("template_scripts", knitr::current_input())
+        # knitr::current_input(dir = TRUE) returns the full path to the file
+        # actually being knit — i.e. the analysis-folder copy of the script —
+        # rather than a path reconstructed under template_scripts/, which is
+        # always wrong once a session is running from its own analysis folder.
+        knitr::current_input(dir = TRUE)
       } else if (requireNamespace("rstudioapi", quietly = TRUE) && rstudioapi::isAvailable()) {
         rstudioapi::getSourceEditorContext()$path
       } else {
+        # Headless (Rscript / cron / CI) invocation: no reliable script-path
+        # API exists here. Left as NULL intentionally — making this branch
+        # work is separate follow-up work, not part of this fix.
         NULL
       }
     }, error = function(e) NULL)
@@ -28,7 +35,7 @@ generate_analysis_lut <- function(resolved_params, current_file_path = NULL) {
     # Check if current directory matches analysis folder pattern
     # Pattern: IDENTIFIER_XXXX_YYYYMMDD (e.g., SFS25_ABCD_20241222)
     folder_name <- basename(current_dir)
-    analysis_pattern <- "^[A-Z0-9]+_[A-Z0-9]{4}_\\d{8}$"
+    analysis_pattern <- "^[A-Z0-9]+_[0-9a-f]{4}_\\d{8}$"
     
     if (grepl(analysis_pattern, folder_name)) {
       # Look for existing analysis_lut RDS file

--- a/R_functions/prep_dwg_interview_catch.R
+++ b/R_functions/prep_dwg_interview_catch.R
@@ -15,6 +15,9 @@ prep_dwg_interview_catch <- function(
     dwg_catch |> 
     mutate(across(c(species, life_stage, fin_mark, fate), ~replace_na(as.character(.), "NA")))
   
+  est_catch_groups <- est_catch_groups |>
+    mutate(across(c(species, life_stage, fin_mark, fate), ~replace_na(as.character(.), "NA")))
+  
   catches <- map_df(
     1:nrow(est_catch_groups),
     ~dwg_catch_group |>
@@ -24,9 +27,7 @@ prep_dwg_interview_catch <- function(
         str_detect(fin_mark, est_catch_groups$fin_mark[.x]),
         str_detect(fate, est_catch_groups$fate[.x])
       ) |>
-      mutate(
-        est_cg = paste0(unlist(est_catch_groups[.x,]), collapse = "_")
-      ) |>
+      mutate(est_cg = combine_catch_group(est_catch_groups[.x, ])) |>
       group_by(est_cg, interview_id) |>
       summarise(fish_count = sum(fish_count, na.rm = T), .groups = "drop")
   )
@@ -35,7 +36,7 @@ prep_dwg_interview_catch <- function(
   int_cat <- map_df(
     1:nrow(est_catch_groups), 
     ~interview_plus_angler_types |>   
-      mutate(est_cg = paste0(unlist(est_catch_groups[.x,]), collapse = "_"))
+      mutate(est_cg = combine_catch_group(est_catch_groups[.x, ]))
     ) |>
     left_join(catches, by = c("est_cg", "interview_id")) |>
     mutate(fish_count = replace_na(fish_count, 0)) |>

--- a/R_functions/resolve_catch_groups.R
+++ b/R_functions/resolve_catch_groups.R
@@ -1,0 +1,95 @@
+#' Resolve catch groups for estimation
+#'
+#' Dynamically source fishery catch groups from the Postgres creel database.
+#' By default the script param `est_catch_groups` is blank quotes ("") and the
+#' model catch group view (vw_model_catch_group) is queried via
+#' `creelutils::fishery_catchgroups()`, returning the component fields alongside
+#' `combined_catch_group` and `model_catch_group_id`. Users can optionally enter
+#' catch groups manually as a data frame of the four component fields (atomic or
+#' combined with `|`), which always overrides the database and is passed through
+#' verbatim with no database contact — correct formatting of manual entries is
+#' the user's responsibility. Aborts when catch groups are blank and the
+#' database lookup fails or returns no defined groups.
+#'
+#' @details
+#' A fully specified manual entry requires no database connectivity, mirroring
+#' `resolve_dates()`. Catch group ids are joined at upload time in
+#' `creelutils::prep_export()` (where a live connection is required regardless); 
+#' manually entered groups not previously defined in the Creel App at
+#' <https://apps.wdfw-fish.us/> are warned and skipped at upload, but estimate
+#' normally.
+#'
+#' @param fishery character; must match a fishery_lut row when catch groups are blank
+#' @param catch_groups "" (query the database) or a data frame with columns
+#'   species, life_stage, fin_mark, fate
+#' @param observed_only logical; passed to `creelutils::fishery_catchgroups()` on the 
+#' blank path to restrict to catch groups with observed catch. Default FALSE.
+#' @param conn A valid database connection from `creelutils::connect_creel_db()`.
+#'   Optional with NULL default; `creelutils::fishery_catchgroups()` opens and closes 
+#'   a lazy connection internally when NULL. Unused on the manual path.
+#' @return data frame of catch groups; database-sourced rows carry
+#'   `combined_catch_group` and `model_catch_group_id`, manual rows do not
+resolve_catch_groups <- function(
+    fishery,
+    catch_groups,
+    observed_only = FALSE,
+    conn = NULL
+) {
+  components <- c("species", "life_stage", "fin_mark", "fate")
+  
+  # Validate 'observed_only' as single logical
+  if (!is.logical(observed_only) || length(observed_only) != 1L || is.na(observed_only)) {
+    cli::cli_abort("{.arg observed_only} must be a single logical TRUE or FALSE.")
+  }
+  
+  # If catch groups are manually entered as a data frame -> pass through unchanged,
+  # no database contact (keeps fully specified runs offline-reproducible)
+  if (is.data.frame(catch_groups)) {
+    missing <- setdiff(components, colnames(catch_groups))
+    if (length(missing)) {
+      cli::cli_abort(c(
+        "{.arg catch_groups} is missing column{?s} {.field {missing}}.",
+        "i" = "Script YAML `params$est_catch_groups` must be entered as:",
+        " " = "!r data.frame(rbind(c(species = '', life_stage = '', fin_mark = '', fate = '')))"
+      ))
+    }
+    return(catch_groups)
+  }
+  
+  # If catch groups are not entered (param as NULL, NA, length-0, or empty quotes "") -> normalize to ""
+  coerce_blank <- \(x) if (is.null(x) || length(x) != 1 || is.na(x) || !nzchar(x)) "" else as.character(x)
+  if (nzchar(coerce_blank(catch_groups))) {
+    cli::cli_abort(
+      "{.arg catch_groups} must be blank (\"\") to query the database, or a data frame with columns {.field {components}}."
+    )
+  }
+  
+  # Source fishery catch groups from the database
+  cg_rows <- tryCatch(
+    creelutils::fishery_catchgroups(conn = conn, fishery_name = fishery, observed_only = observed_only),
+    error = function(e) e
+  )
+  
+  if (inherits(cg_rows, "error")) {
+    cli::cli_abort(c(
+      "Cannot resolve catch groups for {.val {fishery}}.",
+      "x" = "Lookup failed: {conditionMessage(cg_rows)}",
+      "i" = "and no manual est_catch_groups were supplied."
+    ))
+  }
+  
+  if (nrow(cg_rows) == 0) {
+    reason <- if (observed_only) {
+      "no catch groups with observed catch found in vw_model_catch_group"
+    } else {
+      "no catch groups found in vw_model_catch_group"
+    }
+    cli::cli_abort(c(
+      "Cannot resolve catch groups for {.val {fishery}}.",
+      "x" = "{reason}",
+      "i" = "and no manual est_catch_groups were supplied."
+    ))
+  }
+  
+  as.data.frame(cg_rows)
+}

--- a/R_functions/resolve_catch_groups.R
+++ b/R_functions/resolve_catch_groups.R
@@ -53,7 +53,25 @@ resolve_catch_groups <- function(
         " " = "!r data.frame(rbind(c(species = '', life_stage = '', fin_mark = '', fate = '')))"
       ))
     }
-    return(catch_groups)
+    
+    # Add cols to match fishery_catchgroups() output
+    if (!"fishery_name" %in% names(catch_groups)) {
+      catch_groups$fishery_name <- fishery
+    }
+    if (!"combined_catch_group" %in% names(catch_groups)) { # combined created from components
+      catch_groups$combined_catch_group <- creelutils::combine_catch_group(catch_groups)
+    }
+    if (!"model_catch_group_id" %in% names(catch_groups)) { # uuid col as NA, unknown with manual entry
+      catch_groups$model_catch_group_id <- NA_character_
+    }
+    
+    catch_groups <- dplyr::relocate(
+      catch_groups,
+      dplyr::any_of(c("fishery_name", "combined_catch_group", "model_catch_group_id")),
+      .before = 1
+    )
+    
+    return(as.data.frame(catch_groups))
   }
   
   # If catch groups are not entered (param as NULL, NA, length-0, or empty quotes "") -> normalize to ""
@@ -63,7 +81,7 @@ resolve_catch_groups <- function(
       "{.arg catch_groups} must be blank (\"\") to query the database, or a data frame with columns {.field {components}}."
     )
   }
-  
+
   # Source fishery catch groups from the database
   cg_rows <- tryCatch(
     creelutils::fishery_catchgroups(conn = conn, fishery_name = fishery, observed_only = observed_only),
@@ -91,5 +109,5 @@ resolve_catch_groups <- function(
     ))
   }
   
-  as.data.frame(cg_rows)
+  return(as.data.frame(cg_rows))
 }

--- a/R_functions/resolve_dates.R
+++ b/R_functions/resolve_dates.R
@@ -82,11 +82,35 @@ resolve_dates <- function(
     if (resolved_end < resolved_start) {
       cli::cli_abort("Invalid date range for {.val {fishery}}: end ({resolved_end}) is before start ({resolved_start}).")
     }
+
+    # Derive model run type from the resolved window relative to the true fishery end date:
+    # - estimate window ends before the fishery end date -> "In-season"
+    # - estimate window reaches the fishery end date -> "Post-season"
+    model_run_type <- if (resolved_end < as.Date(fishery_row$fishery_end_date)) {
+      "In-season"
+    } else {
+      "Post-season"
+      }
+      
   } else {
     # Both supplied = verbatim, convert to date to validate format and mirror needs_db date resolution
     resolved_start <- as.Date(est_start_input)
     resolved_end   <- as.Date(est_end_input)
+    
+    # Abort when the resolved window is inverted
+    if (resolved_end < resolved_start) {
+      cli::cli_abort("Invalid date range for {.val {fishery}}: end ({resolved_end}) is before start ({resolved_start}).")
+    }
+    
+    # If both dates supplied manually, no database lookup
+    # model run type set as "Unknown" without database fishery_lut validation
+    model_run_type <- "Unknown"
   }
-  # Return list of resolved start and end dates
-  list(est_date_start = as.character(resolved_start), est_date_end = as.character(resolved_end))
+
+  # Return list of resolved dates and run type
+  list(
+    est_date_start = as.character(resolved_start),
+    est_date_end = as.character(resolved_end),
+    model_run_type = model_run_type
+  )
 }

--- a/R_functions/setup_analysis_structure.R
+++ b/R_functions/setup_analysis_structure.R
@@ -2,18 +2,17 @@
 
 #' Set up analysis folder structure and knitr cache settings
 #' 
-#' @param params List of parameters from Rmd YAML header
+#' @param resolved_params List of parameters from Rmd YAML header
 #' @param analysis_lut Analysis lookup table with folder information
-#' @param est_dates Estimate dates resolved from the database fishery lookup table or manually entered by a user
 #' 
 #' @return List with paths to outputs folders
-setup_analysis_structure <- function(params, analysis_lut, est_dates) {
+setup_analysis_structure <- function(resolved_params, analysis_lut) {
   
   # Define analysis folder path
   analysis_folder_path <- here::here(
     "fishery_analyses", 
-    params$project_name, 
-    params$fishery_name, 
+    resolved_params$project_name, 
+    resolved_params$fishery_name, 
     analysis_lut$analysis_folder
   )
   
@@ -41,7 +40,7 @@ setup_analysis_structure <- function(params, analysis_lut, est_dates) {
   # Define cache location (only create folder if caching is enabled)
   cache_path <- file.path(analysis_folder_path, ".cache")
   
-  if (isTRUE(params$enable_cache)) {
+  if (isTRUE(resolved_params$enable_cache)) {
     if (!dir.exists(cache_path)) {
       dir.create(cache_path, recursive = TRUE)
     }
@@ -54,7 +53,7 @@ setup_analysis_structure <- function(params, analysis_lut, est_dates) {
       fig.keep = "all",
       dev = c("png", "pdf"),
       dpi = 300,
-      cache.extra = list(params, analysis_lut$analysis_id, est_dates),
+      cache.extra = list(resolved_params, analysis_lut$analysis_id),
       cache.lazy = FALSE
     )
   } else {
@@ -75,7 +74,7 @@ setup_analysis_structure <- function(params, analysis_lut, est_dates) {
   cli::cli_alert_info("  Inputs: {.path {outputs_folders$inputs}}")
   cli::cli_alert_info("  Outputs: {.path {outputs_folders$outputs}}")
   cli::cli_alert_info("  Figures: {.path {outputs_folders$figures}}")
-  if (isTRUE(params$enable_cache)) {
+  if (isTRUE(resolved_params$enable_cache)) {
     cli::cli_alert_info("  Cache: {.path {cache_path}}")
   } else {
     cli::cli_alert_warning("  Cache: DISABLED (no .cache folder created)")

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1544,7 +1544,7 @@ save_gt_table(interview_coverage_table, paste0("interview_coverage_table"))
 transformed_pe_data <- list()
 transformed_bss_data <- list()
 #Export data from one or both models
-if (params$export %in% c("database", "local") && !params$model_used %in% c("PE only", "BSS only", "Both models" )) {
+if (resolved_params$export %in% c("database", "local") && !resolved_params$model_used %in% c("PE only", "BSS only", "Both models" )) {
   stop("\nInvalid value for export or model_used parameter.")
 } else {
   
@@ -1554,26 +1554,26 @@ if (params$export %in% c("database", "local") && !params$model_used %in% c("PE o
   }
   
   # Process PE estimates to common format
-  if (exists("estimates_pe") && params$model_used == "PE only") {
+  if (exists("estimates_pe") && resolved_params$model_used == "PE only") {
     cat("Performing 'PE only' transformation.")
-    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params)
+    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params)
   }
   
   # Process BSS estimates to common format
   if (exists("estimates_bss") && params$model_used == "BSS only") {
     cat("Performing 'BSS only' transformation.")
-    transformed_bss_data <- creelutils::process_estimates_bss(params, analysis_lut, estimates_bss)
+    transformed_bss_data <- creelutils::process_estimates_bss(params = resolved_params, analysis_lut, estimates_bss)
   }
   
   # Process PE and BSS model estimates to common format
-  if (exists("estimates_pe") && exists("estimates_bss") && params$model_used == "Both models") {
+  if (exists("estimates_pe") && exists("estimates_bss") && resolved_params$model_used == "Both models") {
     cat("Performing 'Both models' transformation.")
-    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params)
-    transformed_bss_data <- creelutils::process_estimates_bss(params, analysis_lut, estimates_bss)
+    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params)
+    transformed_bss_data <- creelutils::process_estimates_bss(params = resolved_params, analysis_lut, estimates_bss)
   }
   
   #Combine PE and BSS and perform other transformation steps
-  creel_estimates <- creelutils::transform_estimates(params, dwg, transformed_pe_data, transformed_bss_data)  
+  creel_estimates <- creelutils::transform_estimates(params = resolved_params, dwg, transformed_pe_data, transformed_bss_data)  
 
 }
 
@@ -1584,7 +1584,7 @@ if (params$export %in% c("database", "local") && !params$model_used %in% c("PE o
 
 ```{r export_estimates, results='hide', eval= TRUE}
 
-if (params$export == "database") {
+if (resolved_params$export == "database") {
   #Converts metadata to JSON and adds to analysis_lut
   #Connects to database
   #calls prep_export()
@@ -1596,7 +1596,7 @@ if (params$export == "database") {
   
   creelutils::export_estimates(resolved_params, est_catch_groups, analysis_lut, creel_estimates, conn = con)
   
-} else if (params$export == "local") {
+} else if (resolved_params$export == "local") {
   # Save all export tables to outputs folder
   cli_alert_info("Exporting estimates to local files...")
   

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -20,7 +20,7 @@ params:
   bss_model_file_name: "BSS_creel_model_02_2021-01-22_ppc.stan"
   model_used: "Both models"
   data_grade: "provisional"
-  export: "local"
+  export: "database"
   export_tables: "both"
   enable_cache: FALSE  # Set to FALSE to disable all caching (useful when cached files become too large)
 output:

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -110,6 +110,19 @@ est_catch_groups <- resolve_catch_groups(
   observed_only = FALSE,
   conn = con
 )
+
+# Snapshot of resolved parameters: YAML params overlaid with resolver
+# outputs. Single source for params_json, generate_analysis_lut(), and
+# the export pipeline (drop-in superset of params).
+resolved_params <- utils::modifyList(
+  unclass(params),
+  c(
+    est_dates[c("est_date_start", "est_date_end", "model_run_type")],
+    list(est_catch_groups = est_catch_groups[
+      c("combined_catch_group", "model_catch_group_id")
+    ])
+  )
+)
 ```
 
 #### Selected catch groups
@@ -220,12 +233,11 @@ current_file <- tryCatch({
 }, error = function(e) NULL)
 
 ## Generate or load analysis_lut (uses existing function as-is)
-generate_analysis_lut(params, current_file_path = current_file)
+generate_analysis_lut(resolved_params, current_file_path = current_file)
 
 # Display analysis metadata
 cli_alert_info("Analysis ID: {.val {analysis_lut$analysis_id}}")
-cli_alert_info("Analysis Folder: {.val {analysis_lut$analysis_folder}}")
-cli_alert_info("Identifier: {.val {analysis_lut$identifier}}")
+cli_alert_info("Analysis Folder: {.val {analysis_lut$analysis_folder_name}}")
 
 # Create analysis folder structure and configure knitr
 # THIS will set the cache.path and fig.path correctly
@@ -1545,18 +1557,12 @@ if (params$export %in% c("database", "local") && !params$model_used %in% c("PE o
   if (exists("estimates_pe") && params$model_used == "PE only") {
     cat("Performing 'PE only' transformation.")
     transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params)
-    
-    #add parameter data_grade as a field on all tables
-    creelutils::map_data_grade(params, transformed_bss_data=NULL, transformed_pe_data)
   }
   
   # Process BSS estimates to common format
   if (exists("estimates_bss") && params$model_used == "BSS only") {
     cat("Performing 'BSS only' transformation.")
     transformed_bss_data <- creelutils::process_estimates_bss(params, analysis_lut, estimates_bss)
-    
-    #add parameter data_grade as a field on all tables
-    creelutils::map_data_grade(params, transformed_bss_data, transformed_pe_data=NULL)
   }
   
   # Process PE and BSS model estimates to common format
@@ -1564,9 +1570,6 @@ if (params$export %in% c("database", "local") && !params$model_used %in% c("PE o
     cat("Performing 'Both models' transformation.")
     transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params)
     transformed_bss_data <- creelutils::process_estimates_bss(params, analysis_lut, estimates_bss)
-    
-    #add parameter data_grade as a field on all tables
-    creelutils::map_data_grade(params, transformed_bss_data, transformed_pe_data)
   }
   
   #Combine PE and BSS and perform other transformation steps
@@ -1591,10 +1594,7 @@ if (params$export == "database") {
   
   con <- creelutils::connect_creel_db()
   
-  analysis_lut <- analysis_lut |> 
-    dplyr::select(-fishery_name, -identifier, -analysis_folder, -created_datetime)
-  
-  creelutils::export_estimates(conn = con , params, analysis_lut, creel_estimates)
+  creelutils::export_estimates(resolved_params, est_catch_groups, analysis_lut, creel_estimates, conn = con)
   
 } else if (params$export == "local") {
   # Save all export tables to outputs folder

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -70,7 +70,7 @@ library("bayesplot")
 library("digest")
 
 # Load packages from source
-# devtools::install_github("wdfw-fp/creelutils")
+# devtools::install_github("dfw-wa/creelutils")
 library(creelutils)
 ```
 
@@ -107,7 +107,7 @@ est_dates <- resolve_dates(
 est_catch_groups <- resolve_catch_groups(
   fishery       = params$fishery_name,
   catch_groups  = params$est_catch_groups,
-  observed_only = FALSE,
+  observed_only = TRUE,
   conn = con
 )
 
@@ -1573,28 +1573,25 @@ if (resolved_params$export %in% c("database", "local") && !resolved_params$model
   }
   
   #Combine PE and BSS and perform other transformation steps
-  creel_estimates <- creelutils::transform_estimates(params = resolved_params, dwg, transformed_pe_data, transformed_bss_data)  
-
+  creel_estimates <- creelutils::transform_estimates(
+    params = resolved_params, 
+    transformed_pe_data, 
+    transformed_bss_data
+  )  
 }
-
-# Save transformed estimates locally
-# saveRDS(creel_estimates, file.path(outputs_folders$outputs, "creel_estimates_transformed.rds"))
-# cli_alert_success("Transformed estimates saved to {.path {file.path(outputs_folders$outputs, 'creel_estimates_transformed.rds')}}")
 ```
 
 ```{r export_estimates, results='hide', eval= TRUE}
 
 if (resolved_params$export == "database") {
-  #Converts metadata to JSON and adds to analysis_lut
-  #Connects to database
-  #calls prep_export()
-  #Defines functions for writing to database tables
-  #Performs pre- and post- upload QAQC checks
-  # creelutils::export_estimates(params, analysis_lut, creel_estimates)
   
-  con <- creelutils::connect_creel_db()
-  
-  creelutils::export_estimates(resolved_params, est_catch_groups, analysis_lut, creel_estimates, conn = con)
+  creelutils::export_estimates(
+    resolved_params,
+    est_catch_groups, 
+    analysis_lut, 
+    creel_estimates, 
+    conn = con
+  )
   
 } else if (resolved_params$export == "local") {
   # Save all export tables to outputs folder

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -6,9 +6,7 @@ params:
   fishery_name: "Skagit spring Chinook 2026 upper"
   est_date_start: ""
   est_date_end: ""
-  est_catch_groups: !r data.frame(rbind(
-    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'UM', fate = 'Released'),
-    c(species = 'Chinook', life_stage = 'Adult', fin_mark = 'AD', fate = 'Kept')))
+  est_catch_groups: ""
   study_design: "Standard"   
   boat_type_collapse: "Yes"
   fish_location_determines_type: "No"
@@ -76,6 +74,12 @@ library("digest")
 library(creelutils)
 ```
 
+```{r database_con, message=FALSE}
+# Establish a connection to the creel database, carry throughout the session
+# This requires a one-time setup per user
+con <- creelutils::connect_creel_db(db_env = "test") # TEMP argument, remove "db_env = 'test'" use after revview
+```
+
 ```{r, load_functions, message=FALSE}
 # Load CreelEstimates functions (pre-package method)
 walk(list.files(here("R_functions"), full.names = T), source)
@@ -91,14 +95,28 @@ walk(list.files(here("R_functions"), full.names = T), source)
 est_dates <- resolve_dates(
   params$fishery_name, 
   params$est_date_start, 
-  params$est_date_end
+  params$est_date_end,
+  conn = con
+)
+```
+
+```{r resolve_catch_groups, message=FALSE}
+# Dynamically source catch groups from the creel database when the YAML param
+# est_catch_groups is blank (default: ""). Manually entered catch groups always
+# override and require no database connection; validation is up to the user.
+est_catch_groups <- resolve_catch_groups(
+  fishery       = params$fishery_name,
+  catch_groups  = params$est_catch_groups,
+  observed_only = FALSE,
+  conn = con
 )
 ```
 
 #### Selected catch groups
 The following catch groups of fish were selected for generating catch estimates. 
 ```{r, echo = FALSE}
-params$est_catch_groups |> 
+est_catch_groups |> 
+  select(-c(fishery_name, combined_catch_group, model_catch_group_id)) |> 
   mutate(`#` = row_number()) |> 
   relocate(`#`) |> 
   gt() |> 
@@ -519,7 +537,7 @@ tab_style(
       interview_plus_angler_types = interview_plus_angler_types,
       study_design = params$study_design,
       dwg_catch = dwg$catch,
-      est_catch_groups = params$est_catch_groups
+      est_catch_groups = dplyr::select(est_catch_groups, species, life_stage, fin_mark, fate)
     )
 
   # 1.4 - Attach the final formatted interview data set to "dwg_summ"

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1593,7 +1593,9 @@ if (resolved_params$export %in% c("database", "local") && !resolved_params$model
 ```{r export_estimates, results='hide', eval= TRUE}
 
 if (resolved_params$export == "database") {
-  
+# Note for interactive/by-chunk runs: resolved_params (and therefore analysis_lut$params_json)
+# is snapshot in build_resolved_params. Editing params$export after that chunk is not 
+# reflected here or in params_json unless build_resolved_params chunk is re-run.
   creelutils::export_estimates(
     resolved_params,
     est_catch_groups, 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -230,7 +230,7 @@ path_components |>
 current_file <- tryCatch({
   # CASE 1: Knitting
   if (!is.null(knitr::current_input())) {
-    file.path(getwd(), knitr::current_input())
+    knitr::current_input(dir = TRUE)
   # CASE 2: Interactive RStudio
   } else if (requireNamespace("rstudioapi", quietly = TRUE) && rstudioapi::isAvailable()) {
     rstudioapi::getSourceEditorContext()$path
@@ -238,7 +238,6 @@ current_file <- tryCatch({
     NULL
   }
 }, error = function(e) NULL)
-
 ## Generate or load analysis_lut (uses existing function as-is)
 generate_analysis_lut(resolved_params, current_file_path = current_file)
 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -110,6 +110,9 @@ est_catch_groups <- resolve_catch_groups(
   observed_only = TRUE,
   conn = con
 )
+```
+
+```{r build_resolved_params, message=FALSE}
 
 # Snapshot of resolved parameters: YAML params overlaid with resolver
 # outputs. Single source for params_json, generate_analysis_lut(), and

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1559,7 +1559,7 @@ if (resolved_params$export %in% c("database", "local") && !resolved_params$model
   # Process PE estimates to common format
   if (exists("estimates_pe") && resolved_params$model_used == "PE only") {
     cat("Performing 'PE only' transformation.")
-    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params)
+    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params, days = dwg$days)
   }
   
   # Process BSS estimates to common format
@@ -1571,7 +1571,7 @@ if (resolved_params$export %in% c("database", "local") && !resolved_params$model
   # Process PE and BSS model estimates to common format
   if (exists("estimates_pe") && exists("estimates_bss") && resolved_params$model_used == "Both models") {
     cat("Performing 'Both models' transformation.")
-    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params)
+    transformed_pe_data <- creelutils::process_estimates_pe(analysis_lut, estimates_pe, params = resolved_params, days = dwg$days)
     transformed_bss_data <- creelutils::process_estimates_bss(params = resolved_params, analysis_lut, estimates_bss)
   }
   

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -3,7 +3,7 @@ title: "Freshwater Creel Report <br>`r params$fishery_name`"
 date: "`r Sys.Date()`"
 params:
   project_name: "District 14"
-  fishery_name: "Skagit spring Chinook 2026 upper"
+  fishery_name: "Skagit spring Chinook 2025 upper"
   est_date_start: ""
   est_date_end: ""
   est_catch_groups: ""
@@ -62,7 +62,7 @@ library("digest")
 
 # Load packages from source
 # devtools::install_github("dfw-wa/creelutils")
-library(creelutils)
+# library(creelutils)
 ```
 
 ```{r database_con, message=FALSE}
@@ -104,16 +104,18 @@ est_catch_groups <- resolve_catch_groups(
 ```
 
 ```{r build_resolved_params, message=FALSE}
-
-# Snapshot of resolved parameters: YAML params overlaid with resolver
-# outputs. Single source for params_json, generate_analysis_lut(), and
-# the export pipeline (drop-in superset of params).
+# Snapshot of resolved parameters. The actual values used, representing 'params' 
+# defined in the analysis script and those sourced from the database. 
+# 'resolved_params' used everywhere downstream as full replacement of stock 'params'.
 resolved_params <- utils::modifyList(
   unclass(params),
   c(
+    # Append resolved fishery dates and model run type (In-season, Post-season)
     est_dates[c("est_date_start", "est_date_end", "model_run_type")],
+    # Append resolved catch groups, retaining combined catch group (i.e., est_cg) 
+    # crosswalk to associated database uuid (unavailable when manually entered in YAML)
     list(est_catch_groups = est_catch_groups[
-      c("combined_catch_group", "model_catch_group_id")
+      c("combined_catch_group", "model_catch_group_id") 
     ])
   )
 )
@@ -132,6 +134,9 @@ cat("</details>\n")
 #### Selected catch groups
 The following catch groups of fish were selected for generating catch estimates. 
 ```{r, echo = FALSE}
+# Using object here instead of resolved_params$est_catch_groups as it does not retain
+# the four catch group fields, which just present a little cleaner in this table
+# rather than the single combined_catch_group field
 est_catch_groups |> 
   select(-c(fishery_name, combined_catch_group, model_catch_group_id)) |> 
   mutate(`#` = row_number()) |> 
@@ -147,10 +152,10 @@ est_catch_groups |>
 
 #### Fishery dates
 
-```{r, eval=params$report_type %in% c("detailed","summary")}
+```{r}
 tibble(
-  `Start date`= format(as.Date(est_dates$est_date_start), "%m/%d/%Y"),
-  `End date` = format(as.Date(est_dates$est_date_end), "%m/%d/%Y")
+  `Start date`= format(as.Date(resolved_params$est_date_start), "%m/%d/%Y"),
+  `End date` = format(as.Date(resolved_params$est_date_end), "%m/%d/%Y")
 ) |> 
   gt() |> 
 tab_header(
@@ -168,7 +173,7 @@ tab_header(
 knitr::opts_chunk$set(
   warning = FALSE,
   message = FALSE,
-  cache = FALSE,          # Will be set based on params$enable_cache
+  cache = FALSE,          # Will be set based on resolved_params$enable_cache
   fig.width = 10,
   fig.height = 8
 )
@@ -179,11 +184,11 @@ rstan_options(auto_write = TRUE)
 # Global R settings
 theme_set(theme_light()) #ggplot theme
 
-# Create hash for cache invalidation when params change
-param_hash <- digest::digest(list(params, est_dates))
+# Create hash for cache invalidation when resolved_params change
+param_hash <- digest::digest(resolved_params)
 
 # Display cache status
-if (params$enable_cache) {
+if (resolved_params$enable_cache) {
   cli_alert_success("Cache is ENABLED - cached results will be reused when possible")
 } else {
   cli_alert_warning("Cache is DISABLED - all chunks will be re-executed")
@@ -191,7 +196,7 @@ if (params$enable_cache) {
 
 # adjust day_length inputs
 day_length_inputs <- list()
-if(params$day_length_expansion == "manual"){
+if(resolved_params$day_length_expansion == "manual"){
 # Step #1: Select general strategy for [earliest] start and [latest] end time
     day_length_inputs$start_time<-c("manual") # enter either "sunrise" or "manual" 
     day_length_inputs$end_time<-c("sunset")    # enter either "sunset"  or "manual" 
@@ -211,8 +216,8 @@ if(params$day_length_expansion == "manual"){
 ## Define directory structure
 path_components <- list(
   here("fishery_analyses"),
-  here("fishery_analyses", params$project_name),
-  here("fishery_analyses", params$project_name, params$fishery_name)
+  here("fishery_analyses", resolved_params$project_name),
+  here("fishery_analyses", resolved_params$project_name, resolved_params$fishery_name)
 )
 
 ## Create directories as needed
@@ -222,7 +227,7 @@ path_components |>
     message(glue("Folder(s) created: \n{.x}"))
   })
 
-# Generate analyis metadata 
+# Generate analysis metadata 
 ## Get current file path for analysis folder detection
 current_file <- tryCatch({
   # CASE 1: Knitting
@@ -245,7 +250,7 @@ cli_alert_info("Analysis Folder: {.val {analysis_lut$analysis_folder_name}}")
 
 # Create analysis folder structure and configure knitr
 # THIS will set the cache.path and fig.path correctly
-analysis_structure <- setup_analysis_structure(params, analysis_lut, est_dates)
+analysis_structure <- setup_analysis_structure(resolved_params, analysis_lut)
 
 # Extract paths for use in subsequent chunks
 analysis_folder_path <- analysis_structure$analysis_folder_path
@@ -254,7 +259,7 @@ cache_path <- analysis_structure$cache_path
 
 # Copy current Rmd file to analysis folder and save metadata files
 save_analysis_metadata(
-  params = params,
+  params = resolved_params,
   analysis_lut = analysis_lut,
   analysis_folder_path = analysis_folder_path,
   current_file_path = current_file
@@ -321,24 +326,24 @@ save_gt_table <- function(gt_obj, filename) {
 # Fetch and review data
 
 ## Download data
-```{r dwg_fetch, cache=params$enable_cache, results='hide', dependson="setup", cache.extra=param_hash}
-dwg <- creelutils::fetch_dwg(params$fishery_name)
+```{r dwg_fetch, cache=resolved_params$enable_cache, results='hide', dependson="setup", cache.extra=param_hash}
+dwg <- creelutils::fetch_dwg(resolved_params$fishery_name)
 
 # Save raw data
 saveRDS(dwg, file.path(outputs_folders$inputs, "dwg_raw.rds"))
 
 dwg$days <- prep_days(
-  params = params,
-  date_begin = est_dates$est_date_start, 
-  date_end = est_dates$est_date_end, 
-  weekends = params$days_wkend,
+  params = resolved_params,
+  date_begin = resolved_params$est_date_start, 
+  date_end = resolved_params$est_date_end, 
+  weekends = resolved_params$days_wkend,
   # holidays = read_lines(paste(here(), "input_files/dates_holidays_2015_2030.txt", sep = "/")),
   lat = mean(dwg$ll$centroid_lat), #can/should consider smarter options
   long = mean(dwg$ll$centroid_lon),#can/should consider smarter options 
-  period_pe = params$period_pe,
+  period_pe = resolved_params$period_pe,
   sections = unique(dwg$interview$section_num),
   closures = dwg$closures,
-  day_length = params$day_length_expansion,
+  day_length = resolved_params$day_length_expansion,
   day_length_inputs = day_length_inputs
   )
 
@@ -381,7 +386,7 @@ dwg$effort |>
 ```{r creel_effort}
 
 dwg$effort |>
-  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |>
+  filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |>
   distinct(section_num, location, event_date, tie_in_indicator, count_sequence) |>
   count(section_num, location, tie_in_indicator) |>
   mutate(
@@ -421,13 +426,13 @@ tab_header(
   ## NOTE: NAs in the "effort_type.y" column indicate that a census survey was conducted without the paired index count; if this occurs, the census data without a paired index count needs to be filter out for BSS model to run
 left_join(
   dwg$effort |>
-    filter(tie_in_indicator == 1, between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
+    filter(tie_in_indicator == 1, between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |> 
     mutate(effort_type = "Census") |> 
     select(water_body, event_date, section_num, effort_type) |> 
     distinct() |> 
     arrange(event_date, section_num),
   dwg$effort |>
-    filter(tie_in_indicator == 0, between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
+    filter(tie_in_indicator == 0, between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |> 
     mutate(effort_type = "Index") |> 
     select(water_body, event_date, section_num, effort_type) |> 
     distinct() |> 
@@ -441,7 +446,7 @@ left_join(
 ```{r creel_interview}
 # Total number of angler group interviews by section_num and fishing_location
 dwg$interview |>
-  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |>
+  filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |>
   count(section_num, fishing_location) |>
   arrange(section_num) |>
   gt() |> 
@@ -471,7 +476,7 @@ tab_style(
 ```{r interviews_date_section, include=FALSE}
 # Number of angler group interviews by event_date and section_num; 
 dwg$interview |>  
-  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
+  filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |> 
   count(section_num, event_date) |> 
   pivot_wider(names_from = section_num, values_from = n) |> 
   arrange(event_date) |> 
@@ -486,7 +491,7 @@ dwg$interview |>
 # Total number of "encounters" for each unique catch_group recorded during angler group interviews
 dwg$catch |>
   left_join(dwg$interview, by = "interview_id") |> 
-  filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))) |> 
+  filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))) |> 
   group_by(catch_group) |> 
   summarise(fish_count = sum(fish_count), .groups = "drop") |> 
 gt() |>
@@ -517,7 +522,7 @@ tab_style(
 
 ## Shared data aggregation
 
-```{r prep_dwg_summ_shared_summary_objects, results = 'hide', cache=params$enable_cache, dependson="dwg_fetch", cache.extra=param_hash}
+```{r prep_dwg_summ_shared_summary_objects, results = 'hide', cache=resolved_params$enable_cache, dependson="dwg_fetch", cache.extra=param_hash}
 # Create blank list that will be used to attach the following three datasets
   dwg_summ <- list() #intermediate objects wrangled from creel list elements
 
@@ -525,22 +530,22 @@ tab_style(
   # 1.1 - Summarize fishing time 
   interview_fishing_time <- 
     prep_dwg_interview_fishing_time(
-      params = params,
-      dwg_interview = dwg$interview |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
-      #person_count_type = params$person_count_type,
-      min_fishing_time = params$min_fishing_time,
-      study_design = params$study_design
+      params = resolved_params,
+      dwg_interview = dwg$interview |> filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))),
+      #person_count_type = resolved_params$person_count_type,
+      min_fishing_time = resolved_params$min_fishing_time,
+      study_design = resolved_params$study_design
     )
   
   # 1.2 - Summarize angler types (angler_final based on arguments)
   interview_plus_angler_types <- 
     prep_dwg_interview_angler_types(
-      params = params,
+      params = resolved_params,
       interview_fishing_time = interview_fishing_time,
-      study_design = params$study_design,
-      boat_type_collapse = params$boat_type_collapse,
-      fish_location_determines_type = params$fish_location_determines_type,
-      angler_type_kayak_pontoon = params$angler_type_kayak_pontoon
+      study_design = resolved_params$study_design,
+      boat_type_collapse = resolved_params$boat_type_collapse,
+      fish_location_determines_type = resolved_params$fish_location_determines_type,
+      angler_type_kayak_pontoon = resolved_params$angler_type_kayak_pontoon
     )
   
     # 1.2.1 - Preview angler_final designations
@@ -549,9 +554,9 @@ tab_style(
   # 1.3 - Summarize catch (for catch groups of interest)
   interview_plus_catch <- 
     prep_dwg_interview_catch(
-      params = params,
+      params = resolved_params,
       interview_plus_angler_types = interview_plus_angler_types,
-      study_design = params$study_design,
+      study_design = resolved_params$study_design,
       dwg_catch = dwg$catch,
       est_catch_groups = dplyr::select(est_catch_groups, species, life_stage, fin_mark, fate)
     )
@@ -574,12 +579,12 @@ tab_style(
     
       effort_index_summ <- 
         prep_dwg_effort_index(
-          params = params,
-          eff = dwg$effort |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
-          study_design = params$study_design,
-          boat_type_collapse = params$boat_type_collapse,
-          fish_location_determines_type = params$fish_location_determines_type,
-          angler_type_kayak_pontoon = params$angler_type_kayak_pontoon
+          params = resolved_params,
+          eff = dwg$effort |> filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))),
+          study_design = resolved_params$study_design,
+          boat_type_collapse = resolved_params$boat_type_collapse,
+          fish_location_determines_type = resolved_params$fish_location_determines_type,
+          angler_type_kayak_pontoon = resolved_params$angler_type_kayak_pontoon
         )
       
     # 2.1.1 - Summary of count_types and their corresponding "angler_final" designation
@@ -597,12 +602,12 @@ tab_style(
     ##NOTE: a warning message will appear indicating "...an unexpected many-to-many relationship..." if multiple effort census counts were completed in the same section and day; this message can be ignored as the data wrangling works as intended despite this warning
     effort_census_summ <- 
       prep_dwg_effort_census(
-        params = params,
-        eff = dwg$effort |> filter(between(event_date, as.Date(est_dates$est_date_start), as.Date(est_dates$est_date_end))),
-        study_design = params$study_design,
-        boat_type_collapse = params$boat_type_collapse,
-        fish_location_determines_type = params$fish_location_determines_type,
-        angler_type_kayak_pontoon = params$angler_type_kayak_pontoon
+        params = resolved_params,
+        eff = dwg$effort |> filter(between(event_date, as.Date(resolved_params$est_date_start), as.Date(resolved_params$est_date_end))),
+        study_design = resolved_params$study_design,
+        boat_type_collapse = resolved_params$boat_type_collapse,
+        fish_location_determines_type = resolved_params$fish_location_determines_type,
+        angler_type_kayak_pontoon = resolved_params$angler_type_kayak_pontoon
       )
     
     # 3.1.1 - QAQC - are there any census effort count groups that "failed"
@@ -615,7 +620,7 @@ tab_style(
 # 4.) Generate summary table of "p_census" 
     (dwg_summ$census_expan <- 
       prep_dwg_census_expan(
-        params = params,
+        params = resolved_params,
         eff = dwg$effort,
         days = dwg$days
       ))  
@@ -626,24 +631,24 @@ saveRDS(dwg_summ, file.path(outputs_folders$inputs, "dwg_summ.rds"))
 
 ## Plot of index effort counts
 
-```{r plot_index_effort_counts, cache=params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", fig.cap= "Index effort counts for each count sequence on surveyed days within the monitoring period. Index counts represent the sum of counts completed at each sampling site during a drive around effort count."}
+```{r plot_index_effort_counts, cache=resolved_params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", fig.cap= "Index effort counts for each count sequence on surveyed days within the monitoring period. Index counts represent the sum of counts completed at each sampling site during a drive around effort count."}
 # plot of index effort counts faceted by section and count_type per count sequence and day 
 
 plot_inputs_pe_index_effort_counts(
-  params = params,
+  params = resolved_params,
   effort_index = dwg_summ$effort_index,
   outputs_folders = outputs_folders)
 ```
 
 # Effort and catch estimation
 
-This section contains preliminary estimates of angler effort and catch during the `r paste(params$fishery_name)` fishery. Settings for the Bayesian state space creel model are contained in folded code, select "show" to view the settings used for this report, including priors used for model parameters and sampler settings. 
+This section contains preliminary estimates of angler effort and catch during the `r paste(resolved_params$fishery_name)` fishery. Settings for the Bayesian state space creel model are contained in folded code, select "show" to view the settings used for this report, including priors used for model parameters and sampler settings. 
 
 ## PE estimation
 
 ### Create PE input object
 
-```{r prep_inputs_pe, results = 'hide', cache=params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", cache.extra=param_hash}
+```{r prep_inputs_pe, results = 'hide', cache=resolved_params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", cache.extra=param_hash}
 
 inputs_pe <- list()
 
@@ -659,7 +664,7 @@ inputs_pe <- list()
   (inputs_pe$interview_ang_per_object <- 
     prep_inputs_pe_int_ang_per_object(
       dwg_summarized = dwg_summ, 
-      study_design = params$study_design
+      study_design = resolved_params$study_design
     ))
 
 # Calculate tie-in (aka census) count expansion factor by section & angler_final
@@ -671,7 +676,7 @@ inputs_pe <- list()
       dwg_summarized = dwg_summ,
       interview_ang_per_object = inputs_pe$interview_ang_per_object,
       census_expan = dwg_summ$census_expan,
-      study_design = params$study_design
+      study_design = resolved_params$study_design
     ))
   
 # Calculate census-corrected angler effort (mean angler hours) by event_date, angler_type, and section_num
@@ -681,7 +686,7 @@ inputs_pe <- list()
       dwg_summarized = dwg_summ,
       interview_ang_per_object = inputs_pe$interview_ang_per_object,
       paired_census_index_counts = inputs_pe$paired_census_index_counts,
-      study_design = params$study_design
+      study_design = resolved_params$study_design
     ))
 
 # Calculate CPUE and catch_estimates by event_date, angler_type, section_num, and est_cg (aka catch group of interest)
@@ -708,7 +713,7 @@ saveRDS(inputs_pe, file.path(outputs_folders$inputs, "inputs_pe.rds"))
 
 ### Paired census and index angler effort counts
 
-```{r view_paired_census_index_counts, cache=params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_pe")}
+```{r view_paired_census_index_counts, cache=resolved_params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_pe")}
 
 if (nrow(dwg_summ$effort_census) > 0) {
   # table view of census / index surveys and resulting bias term ratio 
@@ -742,12 +747,12 @@ if (nrow(dwg_summ$effort_census) > 0) {
 
 ### Generate PE estimates
 
-```{r estimates_pe, cache=params$enable_cache, dependson="prep_inputs_pe", cache.extra=param_hash}
+```{r estimates_pe, cache=resolved_params$enable_cache, dependson="prep_inputs_pe", cache.extra=param_hash}
 estimates_pe <- list() 
 
 estimates_pe$effort <- 
   est_pe_effort(
-    params = params,
+    params = resolved_params,
     dwg = dwg,
     days = dwg$days,
     pe_inputs_list = inputs_pe
@@ -755,7 +760,7 @@ estimates_pe$effort <-
 
 estimates_pe$catch <- 
   est_pe_catch(
-    params = params,
+    params = resolved_params,
     dwg = dwg,
     days = dwg$days,
     pe_inputs_list = inputs_pe
@@ -766,7 +771,7 @@ saveRDS(estimates_pe, file.path(outputs_folders$outputs, "estimates_pe.rds"))
 ```
 
 ### Effort estimates
-```{r pe_effort_summary, cache=params$enable_cache, cache.extra=param_hash}
+```{r pe_effort_summary, cache=resolved_params$enable_cache, cache.extra=param_hash}
 # effort by section_num
 estimates_pe$effort |>
   group_by(section_num, angler_final) |> 
@@ -775,26 +780,26 @@ estimates_pe$effort |>
     .groups = "drop"
   ) |> 
   pivot_wider(names_from = section_num, values_from = E_sum) |> 
-  gt(caption = paste("Estimated effort (angler hours) by fishing section from", est_dates$est_date_start, "to", est_dates$est_date_end)) |> 
+  gt(caption = paste("Estimated effort (angler hours) by fishing section from", resolved_params$est_date_start, "to", resolved_params$est_date_end)) |> 
   tab_options(
     heading.title.font.size = px(14),
     table.font.color = "black"
   )
 ```
 
-```{r plot_pe_effort_estimates, fig.cap= "Estimated effort (angler-hours) grouped by time strata, section and angler type (angler_final).", cache=params$enable_cache, dependson=c("establish_file_structure", "estimates_pe"), cache.extra=param_hash}
+```{r plot_pe_effort_estimates, fig.cap= "Estimated effort (angler-hours) grouped by time strata, section and angler type (angler_final).", cache=resolved_params$enable_cache, dependson=c("establish_file_structure", "estimates_pe"), cache.extra=param_hash}
 
 # barplot of effort estimates by time stratum, section, and angler type
 plot_est_pe_effort(
   estimates_pe_effort = estimates_pe$effort,
-  period_pe = params$period_pe,
+  period_pe = resolved_params$period_pe,
   outputs_folders = outputs_folders,
   filename = "pe_effort_estimates_")
 ```
 
 ### Catch rate (CPUE) estimates
 
-```{r pe_cpue_period_plots, results = 'hide',  cache=params$enable_cache, dependson= c("prep_inputs_pe","dwg_fetch"), cache.extra=param_hash}
+```{r pe_cpue_period_plots, results = 'hide',  cache=resolved_params$enable_cache, dependson= c("prep_inputs_pe","dwg_fetch"), cache.extra=param_hash}
 # plot of catch rate estimates by catch group, time stratum, section, and angler type
 unique(na.omit(inputs_pe$daily_cpue_catch_est$est_cg)) |> 
 set_names() |> 
@@ -804,7 +809,7 @@ map(
     dwg_summarized = dwg_summ,
     daily_cpue_catch_est = inputs_pe$daily_cpue_catch_est,
     est_catch_group = .x,
-    period_pe = params$period_pe,
+    period_pe = resolved_params$period_pe,
     outputs_folders = outputs_folders,
     filename = paste0("pe_cpue_estimates_", stringr::str_replace_all(.x, "[^[:alnum:]]", "_")) #safe name when using | operator in catch group
   )
@@ -836,7 +841,7 @@ map(
   )
 ```
 
-```{r plot_pe_catch_estimates, results = 'hide', cache=params$enable_cache, dependson="estimates_pe", cache.extra=param_hash}
+```{r plot_pe_catch_estimates, results = 'hide', cache=resolved_params$enable_cache, dependson="estimates_pe", cache.extra=param_hash}
 # barplot of catch estimates by catch group, time stratum, section, and angler type
 unique(na.omit(estimates_pe$catch$est_cg)) |> 
 set_names() |> 
@@ -844,7 +849,7 @@ map(
   ~plot_est_pe_catch(
     estimates_pe_catch = estimates_pe$catch,
     est_catch_group = .x,
-    period_pe = params$period_pe,
+    period_pe = resolved_params$period_pe,
     outputs_folders = outputs_folders,
     filename = paste0("pe_catch_estimates_", stringr::str_replace_all(.x, "[^[:alnum:]]", "_"))) #safe name when using | operator in catch group
 )
@@ -854,7 +859,7 @@ map(
 
 ### Create BSS input object 
 
-```{r prep_inputs_bss, eval=TRUE, cache=params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", cache.extra=param_hash}
+```{r prep_inputs_bss, eval=TRUE, cache=resolved_params$enable_cache, dependson="prep_dwg_summ_shared_summary_objects", cache.extra=param_hash}
 #either a single element list for a single catch_group
 #or a list of bss-input-lists, one for each catch_group
 inputs_bss <- 
@@ -863,11 +868,11 @@ inputs_bss <-
   map(
     ~prep_inputs_bss(
       est_catch_group = .x,
-      period = params$period_bss,
+      period = resolved_params$period_bss,
       days = dwg$days,
       dwg_summarized = dwg_summ,
       census_expan = dwg_summ$census_expan, 
-      study_design = params$study_design, 
+      study_design = resolved_params$study_design, 
       priors = c(
         value_cauchyDF_sigma_eps_C = 0.5,
         value_cauchyDF_sigma_eps_E = 0.5,
@@ -895,7 +900,7 @@ saveRDS(inputs_bss, file.path(outputs_folders$inputs, "inputs_bss.rds"))
 
 ### Generate BSS estimates
 
-```{r estimates_bss, eval=TRUE, results='hide', fig.show='hide', cache=params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_bss"), cache.extra=param_hash}
+```{r estimates_bss, eval=TRUE, results='hide', fig.show='hide', cache=resolved_params$enable_cache, dependson=c("establish_file_structure", "prep_inputs_bss"), cache.extra=param_hash}
 #should work for either single or multiple catch_group 
 
 # ---- CONFIGURATION ----
@@ -916,7 +921,7 @@ for(ecg in names(inputs_bss)) {
   # fit the model to generate estimates 
   ecg_fit <-
     fit_bss(
-      model_file_name = params$bss_model_file_name,
+      model_file_name = resolved_params$bss_model_file_name,
       bss_inputs_list = inputs_bss[[ecg]],
       n_chain = 2,  
       n_cores = 2,
@@ -953,7 +958,7 @@ for(ecg in names(inputs_bss)) {
     inputs_bss = inputs_bss, 
     ecg = ecg,
     dwg = dwg, 
-    params = params))
+    params = resolved_params))
   
   ## store estimates and model fit
   estimates_bss[[ecg]] <- ecg_keep
@@ -1486,7 +1491,7 @@ map_df(estimates_bss, ~.x$overview) |>
 
 ## Estimated total effort sampled by interviews
 
-```{r effort_sampled_by_interviews, eval=TRUE, cache=params$enable_cache, dependson=c("dwg_fetch", "prep_dwg_summ_shared_summary_objects", "estimates_pe"), cache.extra=param_hash}
+```{r effort_sampled_by_interviews, eval=TRUE, cache=resolved_params$enable_cache, dependson=c("dwg_fetch", "prep_dwg_summ_shared_summary_objects", "estimates_pe"), cache.extra=param_hash}
 
 interview_coverage_table <-  est_pe_effort_sampled_by_interviews(
   days = dwg$days, 
@@ -1543,7 +1548,7 @@ save_gt_table(interview_coverage_table, paste0("interview_coverage_table"))
 
 # Save results
 
-```{r transform_estimates, eval = TRUE, results='hide', cache=params$enable_cache, dependson="estimates_bss", cache.extra=param_hash}
+```{r transform_estimates, eval = TRUE, results='hide', cache=resolved_params$enable_cache, dependson="estimates_bss", cache.extra=param_hash}
 #Extract and transform model estimates into a common format
 transformed_pe_data <- list()
 transformed_bss_data <- list()
@@ -1564,7 +1569,7 @@ if (resolved_params$export %in% c("database", "local") && !resolved_params$model
   }
   
   # Process BSS estimates to common format
-  if (exists("estimates_bss") && params$model_used == "BSS only") {
+  if (exists("estimates_bss") && resolved_params$model_used == "BSS only") {
     cat("Performing 'BSS only' transformation.")
     transformed_bss_data <- creelutils::process_estimates_bss(params = resolved_params, analysis_lut, estimates_bss)
   }
@@ -1624,6 +1629,6 @@ if (resolved_params$export == "database") {
   cli_alert_success("All export tables saved to {.path {export_folder}}")
   
 } else {
-  cli_alert_warning("Export parameter is '{params$export}' - no export performed")
+  cli_alert_warning("Export parameter is '{resolved_params$export}' - no export performed")
 }
 ```

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -1594,6 +1594,19 @@ if (resolved_params$export == "database") {
 # Note for interactive/by-chunk runs: resolved_params (and therefore analysis_lut$params_json)
 # is snapshot in build_resolved_params. Editing params$export after that chunk is not 
 # reflected here or in params_json unless build_resolved_params chunk is re-run.
+  connection_alive <- tryCatch({
+    DBI::dbGetQuery(con, "SELECT 1")
+    TRUE
+  }, error = function(error) FALSE)
+
+  if (!connection_alive) {
+    cli::cli_alert_warning("Database connection went stale during analysis; reconnecting before export.")
+    if (DBI::dbIsValid(con)) {
+      try(DBI::dbDisconnect(con), silent = TRUE)
+    }
+    con <- creelutils::connect_creel_db(db_env = "prod")
+  }
+
   creelutils::export_estimates(
     resolved_params,
     est_catch_groups, 

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -63,6 +63,7 @@ library("digest")
 # Load packages from source
 # devtools::install_github("dfw-wa/creelutils")
 # library(creelutils)
+devtools::load_all("C:/Repos/creelutils")
 ```
 
 ```{r database_con, message=FALSE}
@@ -109,16 +110,13 @@ est_catch_groups <- resolve_catch_groups(
 # 'resolved_params' used everywhere downstream as full replacement of stock 'params'.
 resolved_params <- utils::modifyList(
   unclass(params),
-  c(
     # Append resolved fishery dates and model run type (In-season, Post-season)
-    est_dates[c("est_date_start", "est_date_end", "model_run_type")],
-    # Append resolved catch groups, retaining combined catch group (i.e., est_cg) 
-    # crosswalk to associated database uuid (unavailable when manually entered in YAML)
-    list(est_catch_groups = est_catch_groups[
-      c("combined_catch_group", "model_catch_group_id") 
-    ])
+    est_dates[c("est_date_start", "est_date_end", "model_run_type")]
   )
-)
+
+# Append resolved catch groups, retaining combined catch group (i.e., est_cg) 
+# crosswalk to associated database uuid (unavailable when manually entered in YAML)
+resolved_params$est_catch_groups = est_catch_groups[c("combined_catch_group", "model_catch_group_id")]
 ```
 
 #### Report parameters

--- a/template_scripts/fw_creel.Rmd
+++ b/template_scripts/fw_creel.Rmd
@@ -42,15 +42,6 @@ This report is intended to communicate preliminary results of freshwater salmon 
 Please note that the data provided has not yet undergone complete Quality Assurance/Quality Control (QA/QC) procedures and may be subject to revision.
 
 # Setup code chunks
-#### Report parameters
-```{r display_params, results='asis', echo=FALSE}
-cat('<details class="params-section">\n')
-cat("<summary>Click to view report parameters</summary>\n\n")
-cat("```yaml\n")
-cat(yaml::as.yaml(params))
-cat("```\n\n")
-cat("</details>\n")
-```
 
 #### Load packages
 ```{r packages, results='hide', message=FALSE, warning=FALSE}
@@ -126,6 +117,16 @@ resolved_params <- utils::modifyList(
     ])
   )
 )
+```
+
+#### Report parameters
+```{r display_params, results='asis', echo=FALSE}
+cat('<details class="params-section">\n')
+cat("<summary>Click to view report parameters</summary>\n\n")
+cat("```yaml\n")
+cat(yaml::as.yaml(resolved_params))
+cat("```\n\n")
+cat("</details>\n")
 ```
 
 #### Selected catch groups

--- a/tests/database-upload-review.R
+++ b/tests/database-upload-review.R
@@ -1,0 +1,556 @@
+# ==============================================================================
+# Post-upload inspection — "what actually landed in the database?"
+#
+# Run after a successful fw_creel.Rmd render with params$export == "database".
+# Set `analysis_id` below; everything else derives from it. Run top to bottom.
+#
+# PREREQUISITE — this script reads ETL 2.0 contracts. In a FRESH R session,
+# before anything else:
+#   remove.packages("creelutils")
+#   remotes::install_github("dfw-wa/creelutils@feature/ETL-catch-groups",
+#                           force = TRUE, upgrade = "never")
+#   # restart R again, then confirm:
+#   pkgload::is_dev_package("creelutils")             # FALSE
+#   packageDescription("creelutils")$RemoteRef        # feature/ETL-catch-groups
+#   args(creelutils::fishery_catchgroups)             # must show observed_only
+#
+# Scope: creel.model_analysis_lut, creel.model_estimates_total,
+#        creel.model_estimates_stratum, and their vw_ reporting views.
+#
+# Section 5 additionally diffs the database against the local `creel_estimates`
+# object from the render session, if it is still in scope. Everything else runs
+# from the analysis_id alone, so a reviewer can inspect someone else's upload.
+#
+# ------------------------------------------------------------------------------
+# WHAT IS ON EACH TABLE  (ETL 2.0 — creelutils@feature/ETL-catch-groups)
+# ------------------------------------------------------------------------------
+# All three tables additionally carry four DATABASE-OWNED audit columns that R
+# never writes and must never send: created_datetime, created_by,
+# modified_datetime, modified_by. They are excluded from every contract check
+# below. modified_* stay NULL until a row is updated in place.
+#
+# model_analysis_lut  — exactly ONE row per analysis run. The reproducibility
+#   record. Column contract is asserted by finalize_analysis_lut():
+#     analysis_id ............ uuid PK, lowercased, generated per session
+#     project_id, fishery_id . uuids resolved from project_lut / fishery_lut at
+#                              finalize time; project_name/fishery_name are
+#                              dropped on the database branch
+#     data_grade ............. "Provisional" | "Approved" (title-cased, validated)
+#     model_run_type ......... "In-season" | "Post-season" | "Unknown"
+#                              ("Unknown" = both dates entered manually)
+#     git_sha, git_tag ....... repo state at run time; git_tag is NA unless HEAD
+#                              points at a tag
+#     analysis_folder_name ... IDENTIFIER_LAST4_YYYYMMDD
+#     params_json ............ resolved_params snapshot: YAML params overlaid
+#                              with resolver output (dates, run type, and the
+#                              catch groups WITH their model_catch_group_ids)
+#     r_session_json ......... sessionInfo capture, added at finalize
+#     analysis_json,
+#     fishery_regulation_json  currently omitted -> NULL on the database side
+#     comment_txt ............ NA unless set
+#
+# model_estimates_stratum — fine grain. One row per
+#   section x time stratum x day_type x angler_type x catch group x model x
+#   estimate_type. Written by prep_export() -> write_stratum():
+#     * est_cg / project_name / fishery_name are DROPPED (ids only)
+#     * angler_final is DROPPED in favor of angler_type_id (joined from
+#       angler_type_lut)
+#     * NaN estimate_value is coerced to 0 (stratum only)
+#     * diagnostics are FILTERED OUT: n_eff, r_hat, n_div, standard_error,
+#       standard_deviation — these are total-scale only by design
+#
+# model_estimates_total — season//window totals. Same standardized long shape,
+#   RETAINS all estimate_types including diagnostics. No angler_type_id.
+#
+# Shared vocabulary (transform_estimates()):
+#   estimate_category : catch | effort | cpue    (cpue is stratum-only)
+#   estimate_type     : 18 valid values, see `valid_types` below
+#   model_catch_group_id : NA on EFFORT rows by design (effort is not a
+#                          fish-attribute quantity). Non-NA on catch and cpue.
+#   estimate_time_period : params$period_pe or params$period_bss, by model_type
+#
+# vw_model_estimates_* — the base table joined out to human-readable names
+#   (species / life_stage / fin_mark / fate, angler type, project, fishery)
+#   plus model_run_type and data_grade denormalized down from the lut. Drops the
+#   surrogate PK and the audit columns. Row counts MUST equal the base table; a
+#   difference means join fan-out.
+# ==============================================================================
+
+library(dplyr)
+library(tidyr)
+library(creelutils)
+
+# check that pre-export object is loaded for comparison
+creel_estimates <- creel_estimates 
+
+# ---- 0. Target -------------------------------------------------------------
+
+analysis_id <- "18a8cf99-a514-40b3-8628-80369c22268f"
+
+f <- glue::glue("analysis_id == '{analysis_id}'")
+
+lut        <- fetch_db_table(conn = con, "creel", "model_analysis_lut",         filter = f)
+total      <- fetch_db_table(conn = con, "creel", "model_estimates_total",      filter = f)
+stratum    <- fetch_db_table(conn = con, "creel", "model_estimates_stratum",    filter = f)
+total_vw   <- fetch_db_table(conn = con, "creel", "vw_model_estimates_total",   filter = f)
+stratum_vw <- fetch_db_table(conn = con, "creel", "vw_model_estimates_stratum", filter = f)
+
+# Reference vocabularies, mirrored from transform_estimates()
+valid_types    <- c("total_catch", "total_effort", "daily_mean", "daily_variance",
+                    "number_observations", "days_open", "mean", "standard_deviation",
+                    "standard_error", "quantile_2_5", "quantile_25", "quantile_50",
+                    "quantile_75", "quantile_97_5", "r_hat", "n_eff", "n_div",
+                    "degrees_freedom")
+stratum_reject <- c("n_eff", "r_hat", "n_div", "standard_error", "standard_deviation")
+lut_contract   <- c("analysis_id", "project_id", "fishery_id", "data_grade",
+                    "model_run_type", "git_sha", "git_tag", "analysis_folder_name",
+                    "params_json", "analysis_json", "r_session_json",
+                    "fishery_regulation_json", "comment_txt")
+
+# Database-owned, added on insert by the table defaults. R never writes these.
+db_audit_cols <- c("created_datetime", "created_by", "modified_datetime", "modified_by")
+
+# ---- 1. Did anything land? -------------------------------------------------
+
+tibble::tibble(
+  object = c("lut", "total", "stratum", "total_vw", "stratum_vw"),
+  nrow   = c(nrow(lut), nrow(total), nrow(stratum), nrow(total_vw), nrow(stratum_vw)),
+  ncol   = c(ncol(lut), ncol(total), ncol(stratum), ncol(total_vw), ncol(stratum_vw))
+)
+# Expect: lut = 1 row. views match their base tables row-for-row.
+
+# ---- 2. analysis_lut against the schema contract ---------------------------
+
+list(
+  missing_from_lut = setdiff(lut_contract, names(lut)),
+  not_in_contract  = setdiff(names(lut), c(lut_contract, db_audit_cols))
+)
+# Both expect character(0). The audit columns are whitelisted — they are added
+# by the database on insert, so their presence is correct, not a contract break.
+
+lut |>
+  select(-ends_with("_json")) |>
+  mutate(across(everything(), as.character)) |>
+  pivot_longer(everything(), names_to = "field", values_to = "value") |>
+  print(n = Inf)
+# Read off: data_grade, model_run_type, git_sha, git_tag, analysis_folder_name.
+# git_sha absent means this run is not reproducible from the repo. git_sha
+# present still does not prove the working tree was clean at run time — that is
+# a known gap until a code_clean flag is added to the lut.
+
+# Which json snapshots are populated vs NULL
+lut |>
+  select(ends_with("_json")) |>
+  summarise(across(everything(), ~ifelse(is.na(.), "NULL", paste0(nchar(.), " chars")))) |>
+  pivot_longer(everything(), names_to = "snapshot", values_to = "state")
+
+# ---- 3. params_json: the reproducibility snapshot --------------------------
+
+lut$params_json |> jsonlite::prettify()
+
+pj <- jsonlite::fromJSON(lut$params_json)
+
+# Headline run parameters
+pj[c("project_name", "fishery_name", "est_date_start", "est_date_end",
+     "model_run_type", "model_used", "data_grade", "export", "export_tables")] |>
+  purrr::map_chr(~paste(as.character(.x), collapse = ", ")) |>
+  tibble::enframe(name = "param", value = "value") |>
+  print(n = Inf)
+# `export` should read "database" for a run that reached these tables. The lut
+# is built once per session by generate_analysis_lut(), so a params value edited
+# after that point will not be reflected here.
+
+# The catch groups the RUN resolved, with the ids it captured
+run_cg <- tibble::as_tibble(pj$est_catch_groups)
+run_cg
+
+# ---- 4. Catch group identity: captured vs written --------------------------
+# The central ETL 2.0 question. Ids in params_json are the run's snapshot;
+# ids in the estimate tables are what was actually keyed on. They must agree.
+
+written_ids <- union(total$model_catch_group_id, stratum$model_catch_group_id)
+written_ids <- written_ids[!is.na(written_ids)]
+
+list(
+  captured_not_written = setdiff(run_cg$model_catch_group_id, written_ids),
+  written_not_captured = setdiff(written_ids, run_cg$model_catch_group_id)
+)
+# Both empty = the crosswalk held end to end.
+# captured_not_written is expected & benign if a defined group had zero catch.
+
+# Human-readable crosswalk behind the UUIDs (names live on the VIEW)
+cg_cols <- intersect(
+  c("model_catch_group_id", "combined_catch_group",
+    "species_name", "life_stage_name", "fin_mark_desc", "fate_name",
+    "species", "life_stage", "fin_mark", "fate"),
+  names(stratum_vw)
+)
+cg_label_cols <- setdiff(cg_cols, "model_catch_group_id")
+
+stratum_vw |>
+  distinct(across(all_of(cg_cols))) |>
+  filter(!is.na(model_catch_group_id)) |>
+  arrange(across(all_of(cg_label_cols)))
+
+# Staleness: are these ids still defined in the database today?
+current_cg <- creelutils::fishery_catchgroups(conn = con, fishery_name = pj$fishery_name)
+setdiff(written_ids, current_cg$model_catch_group_id)
+# Non-empty = a definition was edited or removed since this run. Re-run before
+# treating these estimates as current.
+
+# ---- 5. Local pre-export object vs what landed -----------------------------
+# Requires `creel_estimates` from the render session — the output of
+# transform_estimates(), i.e. BEFORE prep_export(). Skip ahead if not in scope.
+#
+# prep_export() is the ONLY thing between that object and the database:
+#   total   : + model_catch_group_id  (joined est_cg = combined_catch_group)
+#             - est_cg, project_name, fishery_name
+#   stratum : the same, plus
+#             + angler_type_id        (joined angler_final = angler_type_code)
+#             - angler_final
+#             NaN estimate_value coerced to 0
+# Nothing else is added, dropped, filtered, or recomputed — the stratum
+# diagnostic filter already happened inside transform_estimates(). So replaying
+# those steps locally and diffing is a complete audit of the write. The database
+# additionally attaches its surrogate PK and the four audit columns on insert.
+
+cg_xwalk   <- run_cg |> select(combined_catch_group, model_catch_group_id)
+angler_lut <- fetch_db_table(conn = con, "creel", "angler_type_lut") |>
+  select(angler_type_code, angler_type_id)
+
+local_total <- creel_estimates$total |>
+  left_join(cg_xwalk, by = c("est_cg" = "combined_catch_group")) |>
+  select(-any_of(c("est_cg", "project_name", "fishery_name")))
+
+local_stratum <- creel_estimates$stratum |>
+  left_join(cg_xwalk, by = c("est_cg" = "combined_catch_group")) |>
+  left_join(angler_lut, by = c("angler_final" = "angler_type_code")) |>
+  select(-any_of(c("est_cg", "project_name", "fishery_name", "angler_final"))) |>
+  mutate(estimate_value = ifelse(is.nan(estimate_value), 0, estimate_value))
+
+# 5a. Row counts must survive the export unchanged
+tibble::tibble(
+  table = c("total", "stratum"),
+  local = c(nrow(creel_estimates$total), nrow(creel_estimates$stratum)),
+  db    = c(nrow(total), nrow(stratum)),
+  view  = c(nrow(total_vw), nrow(stratum_vw))
+)
+# Any inequality = join fan-out in prep_export(), or a partial write.
+
+# 5b. Column mapping — the *_added lists should be the prep_export() additions
+# plus the surrogate PK and the four database audit columns; nothing else.
+list(
+  total_added     = setdiff(names(total), names(creel_estimates$total)),
+  total_dropped   = setdiff(names(creel_estimates$total), names(total)),
+  stratum_added   = setdiff(names(stratum), names(creel_estimates$stratum)),
+  stratum_dropped = setdiff(names(creel_estimates$stratum), names(stratum))
+)
+
+# 5c. Label resolution — every local est_cg should find an id
+creel_estimates$total |>
+  distinct(est_cg) |>
+  left_join(cg_xwalk, by = c("est_cg" = "combined_catch_group")) |>
+  mutate(expected_unkeyed = is.na(est_cg)) |>
+  arrange(is.na(model_catch_group_id), est_cg)
+# EXPECTED: one row with est_cg = NA and model_catch_group_id = NA. That is the
+# effort rows, which carry no catch group by design (see 8b).
+# FAILURE: any row with a non-NA est_cg and an NA id — the label built by
+# combine_catch_group() did not match the database-built combined_catch_group.
+# prep_export() aborts on this, so it should be impossible here, but it is
+# precisely the failure the catch group migration exists to prevent.
+
+# 5d. Value-level diff, keyed on every shared non-value column
+key_total <- setdiff(intersect(names(local_total), names(total)), "estimate_value")
+key_total
+
+c(local_dupes = anyDuplicated(local_total[key_total]),
+  db_dupes    = anyDuplicated(total[key_total]))
+# Both 0 = the key is unique on each side and the join below is strictly 1:1.
+# Non-zero means the grain is coarser than these columns describe; add the
+# missing key column before trusting the diff.
+
+diff_total <- full_join(local_total, total, by = key_total,
+                        suffix = c("_local", "_db")) |>
+  mutate(delta = estimate_value_db - estimate_value_local)
+
+diff_total |>
+  summarise(n_rows        = n(),
+            only_in_db    = sum(is.na(estimate_value_local)),
+            only_in_local = sum(is.na(estimate_value_db)),
+            n_differing   = sum(abs(delta) > 1e-9, na.rm = TRUE),
+            max_abs_delta = max(abs(delta), na.rm = TRUE))
+
+diff_total |> filter(abs(delta) > 1e-9) |> print(n = 20)   # expect zero rows
+
+key_stratum <- setdiff(intersect(names(local_stratum), names(stratum)), "estimate_value")
+
+diff_stratum <- full_join(local_stratum, stratum, by = key_stratum,
+                          suffix = c("_local", "_db")) |>
+  mutate(delta = estimate_value_db - estimate_value_local)
+
+diff_stratum |>
+  summarise(n_rows        = n(),
+            only_in_db    = sum(is.na(estimate_value_local)),
+            only_in_local = sum(is.na(estimate_value_db)),
+            n_differing   = sum(abs(delta) > 1e-9, na.rm = TRUE),
+            max_abs_delta = max(abs(delta), na.rm = TRUE))
+
+# How many stratum values the NaN -> 0 coercion silently rewrote
+sum(is.nan(creel_estimates$stratum$estimate_value))
+
+# 5e. Type drift across the write (Date vs POSIXct, integer vs numeric)
+tibble::tibble(column = key_total,
+               local  = purrr::map_chr(local_total[key_total], ~class(.x)[1]),
+               db     = purrr::map_chr(total[key_total],       ~class(.x)[1])) |>
+  filter(local != db)
+
+# 5f. Three-way identity: local label -> id -> view names -> label again.
+# The view returns fin_mark as codes (AD|UM|UNK), matching est_cg, so this is a
+# hard equality check. Rebuilding with combine_catch_group() means the view and
+# the run label are compared under the identical join rule used upstream.
+# Needs the ETL 2.0 view column names; adjust the transmute if they change.
+cg_rebuilt <- total_vw |>
+  filter(!is.na(model_catch_group_id)) |>
+  distinct(model_catch_group_id, species_name, life_stage_name,
+           fin_mark_desc, fate_name) |>
+  transmute(model_catch_group_id,
+            species    = species_name,
+            life_stage = life_stage_name,
+            fin_mark   = fin_mark_desc,
+            fate       = fate_name) |>
+  mutate(rebuilt = creelutils::combine_catch_group(
+    pick(species, life_stage, fin_mark, fate)
+  ))
+
+cg_identity <- run_cg |>
+  left_join(select(cg_rebuilt, model_catch_group_id, rebuilt),
+            by = "model_catch_group_id") |>
+  mutate(matches = !is.na(rebuilt) & rebuilt == combined_catch_group)
+
+cg_identity |> print(n = Inf)
+# All TRUE = the label the run built, the id it wrote, and the components the
+# view exposes are the same object. A FALSE here is the silent-zeroing failure
+# mode: estimates compute fine but key to the wrong group.
+
+# ---- 6. What the views add over the base tables ----------------------------
+
+list(
+  total_view_adds    = setdiff(names(total_vw),   names(total)),
+  stratum_view_adds  = setdiff(names(stratum_vw), names(stratum)),
+  total_view_drops   = setdiff(names(total),   names(total_vw)),
+  stratum_view_drops = setdiff(names(stratum), names(stratum_vw))
+)
+# Expected drops: the surrogate PK, the four audit columns, and angler_type_id
+# (replaced by angler_type_name on the stratum view).
+# NOTE: the views currently expose `period_timestep` where the base tables carry
+# `estimate_time_period`. The rename in transform_estimates() has not propagated
+# to the view definitions — tracked in section 13.
+
+names(stratum)   # base grain / key columns
+names(stratum_vw)
+
+# ---- 7. Vocabulary inventory: what was written, by model x category --------
+
+stratum |>
+  count(model_type, estimate_category, estimate_type) |>
+  arrange(model_type, estimate_category, estimate_type) |>
+  print(n = Inf)
+
+total |>
+  count(model_type, estimate_category, estimate_type) |>
+  arrange(model_type, estimate_category, estimate_type) |>
+  print(n = Inf)
+
+# Anything outside the standardized set means a mapping was missed upstream
+list(
+  unstandardized_stratum = setdiff(unique(stratum$estimate_type), valid_types),
+  unstandardized_total   = setdiff(unique(total$estimate_type),   valid_types)
+)
+
+list(
+  stratum_categories = sort(unique(stratum$estimate_category)),  # catch, cpue, effort
+  total_categories   = sort(unique(total$estimate_category))     # catch, effort
+)
+
+# Which estimate_types each model writes, side by side. PE and BSS currently
+# share no point-estimate label at total scale — see section 13.
+bind_rows(stratum = stratum, total = total, .id = "table") |>
+  distinct(table, model_type, estimate_type) |>
+  mutate(present = TRUE) |>
+  pivot_wider(names_from = model_type, values_from = present, values_fill = FALSE) |>
+  arrange(table, estimate_type) |>
+  print(n = Inf)
+
+# ---- 8. Grain and keying invariants ----------------------------------------
+
+# 8a. Diagnostics must be absent from stratum, present on total (BSS runs)
+list(
+  leaked_into_stratum = intersect(unique(stratum$estimate_type), stratum_reject),
+  present_on_total    = intersect(unique(total$estimate_type),   stratum_reject)
+)
+
+# 8b. model_catch_group_id: NA on effort, non-NA on catch/cpue
+bind_rows(stratum = stratum, total = total, .id = "table") |>
+  group_by(table, estimate_category) |>
+  summarise(n_rows   = n(),
+            n_groups = n_distinct(model_catch_group_id, na.rm = TRUE),
+            pct_na   = round(100 * mean(is.na(model_catch_group_id))),
+            .groups  = "drop")
+# Expect pct_na = 100 for effort, 0 for catch and cpue.
+
+# 8c. estimate_time_period should be period_pe for PE, period_bss for BSS
+bind_rows(stratum = stratum, total = total, .id = "table") |>
+  count(table, model_type, estimate_time_period)
+
+# ---- 9. Model coverage per catch group -------------------------------------
+
+stratum_vw |>
+  filter(!is.na(model_catch_group_id)) |>
+  distinct(across(all_of(cg_label_cols)), model_type) |>
+  mutate(present = TRUE) |>
+  pivot_wider(names_from = model_type, values_from = present, values_fill = FALSE)
+# Gaps here mean one model didn't write for a group that the other did.
+
+# ---- 10. Headline point estimates, PE vs BSS -------------------------------
+# PE writes `total_catch`; BSS writes `mean` and quantiles and has no
+# total_catch row, so a naive pivot on estimate_type silently returns PE only.
+# Pull all three labels explicitly.
+
+total_vw |>
+  filter(estimate_category == "catch",
+         (model_type == "PE"  & estimate_type == "total_catch") |
+           (model_type == "BSS" & estimate_type %in% c("mean", "quantile_50"))) |>
+  mutate(label = if_else(model_type == "PE", "PE_total",
+                         paste0("BSS_", estimate_type))) |>
+  select(all_of(cg_label_cols), label, estimate_value) |>
+  pivot_wider(names_from = label, values_from = estimate_value)
+
+total_vw |>
+  filter(estimate_category == "effort",
+         (model_type == "PE"  & estimate_type == "total_effort") |
+           (model_type == "BSS" & estimate_type %in% c("mean", "quantile_50"))) |>
+  mutate(label = if_else(model_type == "PE", "PE_total",
+                         paste0("BSS_", estimate_type))) |>
+  select(label, estimate_value) |>
+  pivot_wider(names_from = label, values_from = estimate_value)
+
+# BSS posterior shape tripwire.
+# mean_vs_median far from 1 = skewed posterior. mean_above_upper is the harder
+# failure: a posterior mean lying outside its own 97.5th percentile is not a
+# usable point estimate at any chain length.
+bss_skew <- total_vw |>
+  filter(model_type == "BSS",
+         estimate_type %in% c("mean", "quantile_50", "quantile_97_5")) |>
+  select(all_of(cg_label_cols), estimate_category, estimate_type, estimate_value) |>
+  pivot_wider(names_from = estimate_type, values_from = estimate_value) |>
+  mutate(mean_vs_median   = mean / quantile_50,
+         mean_above_upper = mean > quantile_97_5) |>
+  arrange(desc(mean_vs_median))
+
+bss_skew |> print(n = Inf)
+
+# BSS convergence, total scale only. Short test chains will trip these; they are
+# here to be read, not to gate a plumbing review.
+total |>
+  filter(estimate_type %in% c("r_hat", "n_eff", "n_div")) |>
+  select(model_catch_group_id, estimate_category, estimate_type, estimate_value) |>
+  pivot_wider(names_from = estimate_type, values_from = estimate_value)
+
+# ---- 11. Value sanity ------------------------------------------------------
+
+bind_rows(stratum = stratum, total = total, .id = "table") |>
+  group_by(table, estimate_category, estimate_type) |>
+  summarise(n     = n(),
+            n_na  = sum(is.na(estimate_value)),
+            n_nan = sum(is.nan(estimate_value)),
+            n_neg = sum(estimate_value < 0, na.rm = TRUE),
+            min   = min(estimate_value, na.rm = TRUE),
+            max   = max(estimate_value, na.rm = TRUE),
+            .groups = "drop") |>
+  arrange(table, estimate_category, estimate_type) |>
+  print(n = Inf)
+# stratum n_nan must be 0 (prep_export coerces NaN -> 0). Negative catch or
+# effort is never valid; negatives on daily_variance / diagnostics are.
+
+# days_open cannot exceed the length of the estimate window. Currently expected
+# to FAIL — process_estimates_pe() builds the total from a distinct() over
+# period/day_type/est_cg/n_obs/N_days_open, which does not collapse sections
+# whose n_obs differ, so section-level values are summed. number_observations
+# is shown alongside because it is likely inflated by the same mechanism.
+days_open_check <- total |>
+  filter(estimate_type %in% c("days_open", "number_observations")) |>
+  mutate(window_days   = as.numeric(max_event_date - min_event_date) + 1,
+         within_window = estimate_value <= window_days) |>
+  select(model_catch_group_id, estimate_category, estimate_type,
+         estimate_value, window_days, within_window)
+
+days_open_check |> print(n = Inf)
+
+# ---- 12. Reviewer summary --------------------------------------------------
+# All TRUE on a healthy upload. Known upstream issues live in section 13 so
+# they do not dilute this signal.
+
+tibble::tribble(
+  ~check,                                ~pass,
+  "lut is exactly one row",              nrow(lut) == 1L,
+  "lut matches schema contract",         length(setdiff(lut_contract, names(lut))) == 0L &&
+    length(setdiff(names(lut),
+                   c(lut_contract, db_audit_cols))) == 0L,
+  "git_sha captured",                    !is.na(lut$git_sha),
+  "views match base row counts",         nrow(total_vw) == nrow(total) &&
+    nrow(stratum_vw) == nrow(stratum),
+  "no unstandardized estimate_types",    length(setdiff(unique(c(stratum$estimate_type,
+                                                                 total$estimate_type)),
+                                                        valid_types)) == 0L,
+  "no diagnostics leaked to stratum",    length(intersect(unique(stratum$estimate_type),
+                                                          stratum_reject)) == 0L,
+  "all written ids were captured in run", length(setdiff(written_ids,
+                                                         run_cg$model_catch_group_id)) == 0L,
+  "written ids still defined in db",     length(setdiff(written_ids,
+                                                        current_cg$model_catch_group_id)) == 0L,
+  "label -> id -> view names round-trip", all(cg_identity$matches),
+  "catch/cpue rows all keyed",           !any(is.na(bind_rows(stratum, total) |>
+                                                      filter(estimate_category != "effort") |>
+                                                      pull(model_catch_group_id))),
+  "no NaN in stratum values",            sum(is.nan(stratum$estimate_value)) == 0L,
+  "no negative catch or effort",         !any(bind_rows(stratum, total) |>
+                                                filter(estimate_category %in% c("catch", "effort"),
+                                                       estimate_type %in% c("total_catch", "total_effort")) |>
+                                                pull(estimate_value) < 0, na.rm = TRUE),
+  # the four below require section 5 to have run
+  "row counts survived export",          nrow(creel_estimates$total) == nrow(total) &&
+    nrow(creel_estimates$stratum) == nrow(stratum),
+  "export join key is 1:1",              anyDuplicated(local_total[key_total]) == 0L &&
+    anyDuplicated(local_stratum[key_stratum]) == 0L,
+  "total values round-trip exactly",     sum(abs(diff_total$delta) > 1e-9, na.rm = TRUE) == 0L &&
+    !any(is.na(diff_total$estimate_value_db)),
+  "stratum values round-trip exactly",   sum(abs(diff_stratum$delta) > 1e-9, na.rm = TRUE) == 0L &&
+    !any(is.na(diff_stratum$estimate_value_db))
+)
+
+# ---- 13. Known issues watchlist --------------------------------------------
+# Expected FALSE today. Tracked here rather than in section 12 so that a
+# reviewer can tell "this PR broke something" apart from "this was already
+# broken". Delete a row once its fix lands.
+
+tibble::tribble(
+  ~watch,                                              ~resolved,
+  
+  "days_open <= estimate window length",
+  all(days_open_check$within_window[days_open_check$estimate_type == "days_open"]),
+  
+  "BSS posterior mean within its own 97.5% quantile",
+  !any(bss_skew$mean_above_upper, na.rm = TRUE),
+  
+  "BSS writes a shared point-estimate label",
+  "total_catch" %in% (total |> filter(model_type == "BSS") |> pull(estimate_type)),
+  
+  "views expose estimate_time_period, not period_timestep",
+  !"period_timestep" %in% c(names(total_vw), names(stratum_vw))
+)
+# days_open ......... process_estimates_pe() sums across sections
+# BSS mean .......... fat-tailed posterior on sparse catch groups; also trips on
+#                     deliberately short test chains
+# shared label ...... consumers asking for "the total catch estimate" silently
+#                     get PE only; needs a mapping or a coalescing view
+# period_timestep ... view definitions still on the pre-rename column


### PR DESCRIPTION
**Summary**

This PR wires the analysis template (`fw_creel.Rmd`) to the new database-sourced catch group resolution and export contract added in creelutils (companion PR: [creelutils PR 35](https://github.com/dfw-wa/creelutils/pull/35).  Review both together, as most of the underlying logic lives there). It adds `resolve_catch_groups()`, threads `resolved_params` through the template as the single reproducibility snapshot, and updates the interview-catch prep function to use the shared catch-group labeling rule.

**Data flow / how the repos work together**

1. `fw_creel.Rmd``s `resolve_catch_groups` chunk calls the new `resolve_catch_groups()`, mirroring the existing `resolve_dates()` pattern: a blank ("") `est_catch_groups` YAML param triggers `creelutils::fishery_catchgroups()` against the database; a fully-specified manual data frame passes through verbatim with no database contact, and validating that format is on the user.
2. `resolve_dates()` is extended to also return `model_run_type` ("In-season" if the resolved end date is before the fishery's true end date, "Post-season" otherwise; "Unknown" when both dates are entered manually).
3. Both resolvers' outputs are folded into `resolved_params` by `utils::modifyList(params, ...)` immediately after they run. This is the object that flows into `generate_analysis_lut()`, `params_json`, and the entire export pipeline from that point forward; it is the drop-in superset of params and the reproducibility record of what the run actually resolved to, as opposed to what the YAML said.
4. `generate_analysis_lut()` builds the session `analysis_lut` from `resolved_params`, capturing `git_sha`/`git_tag`, `analysis_folder_name`, and a `params_json` snapshot (including the catch groups with their resolved `model_catch_group_ids`, not just the labels).
5. `prep_dwg_interview_catch()` now builds `est_cg` via `creelutils::combine_catch_group()` at both call sites (the `catches` map and the `int_cat` map), replacing the previous independent `paste0(unlist(...))` calls, and normalizes `est_catch_groups`' component columns (`NA` → "NA") to match the normalization already applied to raw catch data; fixing a crash where a solo-`NA` definition field reached `str_detect()` as a literal `NA` rather than the string "NA".
6. The template's export chunk calls `creelutils::export_estimates(resolved_params, est_catch_groups, analysis_lut, creel_estimates, conn = con)`. The full creelutils ETL rewrite (companion PR) runs from here.
7. `tests/database-upload-review.R` (new) a post-upload review script, run against an `analysis_id` after a database export. It checks the lut against its schema contract, confirms captured catch-group ids match written ids match currently-defined ids (the staleness check), replays `prep_export()`'s transformation on the local pre-export `creel_estimates` object and diffs it against what's in the database, and closes with a pass/fail summary.

**Core changes and decision points**

- `resolved_params` is the most load-bearing addition in this PR. Every downstream consumer (`generate_analysis_lut()`, `params_json`, `export_estimates()`) reads from it instead of raw params, so the reproducibility snapshot always reflects resolver output, not just YAML input.
- `resolve_catch_groups()` mirrors `resolve_dates()` deliberately: same blank-triggers-database-query / manual-overrides-and-requires-no-connection pattern, same "validation of manual entries is the user's responsibility" stance.
- `prep_dwg_interview_catch()` fix closes a real bug: a solo-NA catch-group definition field (as opposed to a piped NA alongside other values) previously crashed `str_detect()` outright rather than silently misbehaving. This PR makes both sides of every `str_detect()` call share the same "NA" token.
- `model_run_type` derivation in `resolve_dates()` is date-window-relative only (compares against the fishery's defined end date, not today's date). Known issue: a truncated re-run of an already-finished fishery will currently read "In-season", planned follow-up and not addressed in this PR.
- Database review script (`tests/database-upload-review.R`) is new process a reviewer should run against their own test upload to confirm the round-trip end to end before approving either PR.