### PR TITLE
Add mapped-drive path shortening (here_short) and fix location_type filter in prep_dwg_census_expan()

### DIFF
--- a/R_functions/here_short.R
+++ b/R_functions/here_short.R
@@ -1,0 +1,96 @@
+#' Project-relative path, shortened via a mapped network drive when available
+#'
+#' Drop-in replacement for `here::here()`. If a mapped drive (default `"O:"`)
+#' points at the same location as the user's OneDrive sync root, the returned
+#' path is rewritten to start with the drive letter instead of the full
+#' `"C:/Users/<username>/OneDrive - ..."` prefix. This is what actually fixes
+#' Windows MAX_PATH (260-character) failures -- Windows resolves a mapped/
+#' substituted drive letter to a short path at the OS level, so tools that
+#' aren't long-path-aware (Explorer, many image viewers, older Office apps)
+#' can open the file even though the "real" underlying path is long.
+#'
+#' The OneDrive root is read from the `OneDriveCommercial` / `OneDrive`
+#' environment variables that OneDrive itself sets on every user's machine,
+#' so this works for any username without hardcoding one -- as long as
+#' everyone has mapped the same drive letter to their OneDrive root (as your
+#' team's setup script already does).
+#'
+#' Falls back to plain `here::here()` (no error, one-time warning) if:
+#'   - not running on Windows,
+#'   - the OneDrive env var can't be found, or
+#'   - the mapped drive isn't currently connected in this R session.
+#'
+#' @param ... path components, passed straight through to `here::here()`
+#' @param mapped_drive drive letter (with colon) mapped to the OneDrive root.
+#'   Defaults to `"O:"`.
+#' @return character; a single absolute path
+#'
+#' @examples
+#' \dontrun{
+#' here_short("fishery_analyses", params$project_name)
+#' # "O:/Projects/Creel/GitHub/CreelEstimates/fishery_analyses/CRM-Roving Creel Project"
+#' # instead of
+#' # "C:/Users/bentlktb/OneDrive - Washington State Executive Branch Agencies/Projects/Creel/GitHub/CreelEstimates/fishery_analyses/CRM-Roving Creel Project"
+#' }
+here_short <- function(..., mapped_drive = "O:") {
+
+  full_path <- here::here(...)
+
+  # Only relevant on Windows -- this whole problem is a Windows path-length thing
+  if (.Platform$OS.type != "windows") {
+    return(full_path)
+  }
+
+  # OneDrive sets one of these env vars to the sync root for the signed-in account.
+  # OneDriveCommercial = work/school account (this is the one you'll want here);
+  # OneDrive = personal account, kept as a fallback.
+  onedrive_root <- Sys.getenv("OneDriveCommercial")
+  if (!nzchar(onedrive_root)) onedrive_root <- Sys.getenv("OneDrive")
+
+  if (!nzchar(onedrive_root)) {
+    cli::cli_alert_warning(
+      "here_short(): could not detect a OneDrive root from environment variables; using the full path."
+    )
+    return(full_path)
+  }
+
+  onedrive_root_norm <- normalizePath(onedrive_root, winslash = "/", mustWork = FALSE)
+  full_path_norm      <- normalizePath(full_path, winslash = "/", mustWork = FALSE)
+
+  # Confirm the mapped drive is actually connected in *this* R session before
+  # rewriting anything -- mapped drives are per-login-session, so this can be
+  # FALSE if RStudio was launched before the drive was (re)mapped.
+  mapped_drive_connected <- dir.exists(paste0(mapped_drive, "/"))
+
+  if (!mapped_drive_connected) {
+    cli::cli_alert_warning(
+      "here_short(): {mapped_drive} is not currently connected; using the full path. \\
+       Map the drive, then restart R/RStudio."
+    )
+    return(full_path)
+  }
+
+  if (!startsWith(full_path_norm, onedrive_root_norm)) {
+    # Project isn't actually under the detected OneDrive root -- nothing to shorten
+    return(full_path)
+  }
+
+  candidate_path <- sub(onedrive_root_norm, mapped_drive, full_path_norm, fixed = TRUE)
+
+  # mapped_drive existing isn't proof it points at the OneDrive root -- it could
+  # be mapped to something unrelated (a stale mapping, a different share, etc.).
+  # Verify by checking that the *project root* -- which is guaranteed to already
+  # exist, since R is running from it -- actually exists at the candidate path too.
+  project_root_candidate <- sub(onedrive_root_norm, mapped_drive, here::here(), fixed = TRUE)
+
+  if (!dir.exists(project_root_candidate)) {
+    cli::cli_alert_warning(
+      "here_short(): {mapped_drive} exists but doesn't appear to point at the \\
+       OneDrive root (expected to find the project at {.path {project_root_candidate}}); \\
+       using the full path instead."
+    )
+    return(full_path)
+  }
+
+  candidate_path
+}

--- a/R_functions/prep_dwg_census_expan.R
+++ b/R_functions/prep_dwg_census_expan.R
@@ -11,7 +11,7 @@ prep_dwg_census_expan <- function(
   
   eff |> 
     dplyr::filter( # filter to only dates specified in params and described in dwg$days object
-      location_type == "Site",
+      location_type == "Section", 
       event_date >= min(days$event_date),
       event_date <= max(days$event_date)
     ) |> 

--- a/R_functions/setup_analysis_structure.R
+++ b/R_functions/setup_analysis_structure.R
@@ -5,17 +5,33 @@
 #' @param params List of parameters from Rmd YAML header
 #' @param analysis_lut Analysis lookup table with folder information
 #' @param est_dates Estimate dates resolved from the database fishery lookup table or manually entered by a user
+#' @param mapped_drive Drive letter (with colon) mapped to the OneDrive root,
+#'   used by `here_short()` to shorten output paths and avoid Windows
+#'   MAX_PATH issues. Defaults to `"O:"`. Set to `NULL` to skip shortening
+#'   and always use the full `here::here()` path.
 #' 
 #' @return List with paths to outputs folders
-setup_analysis_structure <- function(params, analysis_lut, est_dates) {
+setup_analysis_structure <- function(params, analysis_lut, est_dates, mapped_drive = "O:") {
   
-  # Define analysis folder path
-  analysis_folder_path <- here::here(
-    "fishery_analyses", 
-    params$project_name, 
-    params$fishery_name, 
-    analysis_lut$analysis_folder
-  )
+  # Define analysis folder path (shortened via mapped drive when available --
+  # see here_short(); falls back to here::here() if mapped_drive is NULL or
+  # the drive can't be confirmed)
+  analysis_folder_path <- if (!is.null(mapped_drive)) {
+    here_short(
+      "fishery_analyses", 
+      params$project_name, 
+      params$fishery_name, 
+      analysis_lut$analysis_folder,
+      mapped_drive = mapped_drive
+    )
+  } else {
+    here::here(
+      "fishery_analyses", 
+      params$project_name, 
+      params$fishery_name, 
+      analysis_lut$analysis_folder
+    )
+  }
   
   # Create analysis folder
   if (!dir.exists(analysis_folder_path)) {


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled on this branch:

1. Adds `here_short()`, a drop-in replacement for `here::here()` that shortens output paths via a mapped network drive, to avoid Windows MAX_PATH (260-character) failures in deeply nested analysis output folders.
2. Restores the `location_type` filter to `"Section"` in `prep_dwg_census_expan()`.

## 1. Path shortening (`here_short.R`, `setup_analysis_structure.R`)

`setup_analysis_structure()` builds output paths off `here::here()`, which resolves to wherever the `.Rproj` physically sits — inside
OneDrive, this adds a long `C:/Users/<username>/OneDrive - ...` prefix before any of the nested fishery_analyses/<project>/<fishery>/...` structure is added. This caused output files that would generate but
fail to open (R itself handles long paths internally, but Explorer, image viewers, and older Office apps generally don't).

`here_short()` fixes this by rewriting the OneDrive root prefix (read from the `OneDriveCommercial`/`OneDrive` environment variables, so it's username-agnostic) to a mapped drive letter (default `"O:"`) when that drive is connected in the current session. Before trusting thesubstitution, it verifies the project root actually exists at the candidate path — this guards against a drive letter that exists but points somewhere other than the OneDrive root (e.g. a mismapped Teams/SharePoint library), which would otherwise silently write output to the wrong location. Falls back to the full `here::here()` path (with a `cli` warning) if the drive isn't mapped, isn't connected, or the verification fails — no errors, no silent wrong paths.

`setup_analysis_structure()` now takes a `mapped_drive = "O:"` argument (set to `NULL` to opt out entirely).

## 2. `prep_dwg_census_expan()` filter fix

`p_census` (`p_TI`) represents tie-in coverage proportions defined and stored at the section level, with values limited to two
`angler_final` groupings (bank, boat). Filtering on `"Site"` doesn't match the level `p_census` is defined at, and broke the Drano Lake estimate. Restored the filter to `"Section"`.

## Testing

- Path shortening tested locally with `O:` mapped to the OneDrive root; **I did not confirmed fallback behavior (warning, full path) with the drive unmapped or with `O:` mapped to an unrelated folder.  Would be good to test on a computer that doesn't have an "O:" drive set up**
- `prep_dwg_census_expan()` re-run against Drano Lake data to confirm the estimate matches expected output with the "Section"` filter restored.